### PR TITLE
Add ability to query calls made to a route

### DIFF
--- a/__tests__/route-matching-general-tests.js
+++ b/__tests__/route-matching-general-tests.js
@@ -15,6 +15,18 @@ afterEach(() => {
     fakeServer.stop();
 });
 
+test('GET route defined, one call matches and two dont, callsMade returns only the matching call', async () => {
+  const path = '/somePath';
+  const route = http.get().to(path)
+    .willSucceed();
+
+  await fetch(`http://localhost:${port}${path}`, {method: 'GET'});
+  await fetch(`http://localhost:${port}${path}`, {method: 'PUT'});
+  await fetch(`http://localhost:${port}${path}`, {method: 'POST'});
+
+  expect(fakeServer.callsMade(route.call).length).toEqual(1);
+});
+
 test('GET route defined and called - match', async () => {
   const path = '/somePath';
   const route = http.get().to(path)

--- a/src/matchCalls.js
+++ b/src/matchCalls.js
@@ -1,0 +1,37 @@
+import deepEquals from 'deep-equal';
+import isSubset from 'is-subset';
+
+export default function matchCalls(call1, call2) {
+    if (call2.method !== call1.method) {
+        return false;
+    }
+
+    if (!new RegExp(call1.pathRegex).test(call2.path)) {
+        return false;
+    }
+
+    const contentTypeIsApplicationJson = call2.headers['content-type'] === 'application/json';
+    const callBodyAsString = contentTypeIsApplicationJson ? JSON.stringify(call2.body) : call2.body;
+
+    if (call1.bodyRestriction.exactText) {
+        if (callBodyAsString !== call1.bodyRestriction.exactText) {
+            return false;
+        }
+    } else if (call1.bodyRestriction.regex) {
+        if (!new RegExp(call1.bodyRestriction.regex).test(callBodyAsString)) {
+            return false;
+        }
+    }
+
+    if (call1.bodyRestriction.exactObject) {
+        if (!deepEquals(call2.body, call1.bodyRestriction.exactObject)) {
+            return false;
+        }
+    } else if (call1.bodyRestriction.minimalObject) {
+        if (!isSubset(call2.body, call1.bodyRestriction.minimalObject)) {
+            return false;
+        }
+    }
+
+    return true;
+}


### PR DESCRIPTION
* Separated out the logic to match two calls from FakeServer into `matchCalls.js`
* Refactored FakeServer.hasMade to use it instead
* Added FakeServer.callsMade query all calls made to a specific route

I implemented this in userland in some blackbox testing I did, and I think it fits into the core of `simple-fake-server` fairly well isntead :)