### PR TITLE
Simplify public api

### DIFF
--- a/__tests__/body-restrictions-on-assertion-tests.ts
+++ b/__tests__/body-restrictions-on-assertion-tests.ts
@@ -16,173 +16,264 @@ afterEach(() => {
 });
 
 // route defined with regex body restriction
+[{useNewApi: true}, {useNewApi: false}].forEach(({useNewApi}) => {
+    describe('Body restriction on assertion', () => {
+        test('regex restriction, assert on a specific string that matches the regex, request body equals test string - assertion success', async () => {
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path).withBodyThatMatches(lettersRegex).willSucceed();
+            } else {
+                route = fakeServer.post().to(path).withBodyThatMatches(lettersRegex).willSucceed();
+            }
 
-test('regex restriction, assert on a specific string that matches the regex, request body equals test string - assertion success', async () => {
-    const route = fakeServer.post().to(path).withBodyThatMatches(lettersRegex).willSucceed();
-    const actualBody = 'abc';
-    const testString = 'abc';
+            const actualBody = 'abc';
+            const testString = 'abc';
 
-    await fetch(`http://localhost:${port}${path}`, {
-        method: 'POST',
-        headers: {'Content-Type': 'text/plain'},
-        body: actualBody,
+            await fetch(`http://localhost:${port}${path}`, {
+                method: 'POST',
+                headers: {'Content-Type': 'text/plain'},
+                body: actualBody,
+            });
+
+            expect(fakeServer.hasMade(route.call.withBodyText(testString))).toEqual(true);
+        });
+
+        test('regex restriction, assert on a specific string that matches the regex, request body does not equal test string (but matches regex) - assertion success', async () => {
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path).withBodyThatMatches(lettersRegex).willSucceed();
+            } else {
+                route = fakeServer.post().to(path).withBodyThatMatches(lettersRegex).willSucceed();
+            }
+            const actualBody = 'abc';
+            const testString = 'def';
+
+            await fetch(`http://localhost:${port}${path}`, {
+                method: 'POST',
+                headers: {'Content-Type': 'text/plain'},
+                body: actualBody,
+            });
+
+            expect(fakeServer.hasMade(route.call.withBodyText(testString))).toEqual(false);
+        });
+
+        test('regex restriction, assert on a specific string that does not match the regex - exception', () => {
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path).withBodyThatMatches(lettersRegex).willSucceed();
+            } else {
+                route = fakeServer.post().to(path).withBodyThatMatches(lettersRegex).willSucceed();
+            }
+
+            expect(() => route.call.withBodyText('123')).toThrow();
+        });
+
+        test('regex restriction, passing something other than string to specific string method - exception', () => {
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path).withBodyThatMatches(lettersRegex).willSucceed();
+            } else {
+                route = fakeServer.post().to(path).withBodyThatMatches(lettersRegex).willSucceed();
+            }
+
+            expect(() => route.call.withBodyText({} as string)).toThrow();
+        });
+
+        test('regex restriction, assert on a specific object - exception', () => {
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path).withBodyThatMatches(lettersRegex).willSucceed();
+            } else {
+                route = fakeServer.post().to(path).withBodyThatMatches(lettersRegex).willSucceed();
+            }
+
+            expect(() => route.call.withSpecificBody({})).toThrow();
+        });
+
+        // route defined with partial object body restriction
+
+        test('partial object restriction, assert on a specific object that matches the partial object, request body equals test object - assertion success', async () => {
+            const expectedPartialBody = {a: 1};
+            const actualBody = {a: 1, b: 2};
+            const testBody = {a: 1, b: 2};
+
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path).withBodyThatContains(expectedPartialBody).willSucceed();
+            } else {
+                route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody).willSucceed();
+            }
+
+            await fetch(`http://localhost:${port}${path}`, {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify(actualBody),
+            });
+
+            expect(fakeServer.hasMade(route.call.withSpecificBody(testBody))).toEqual(true);
+        });
+
+        test('partial object restriction, assert on a specific object that matches the partial object, request body does not equal test object (but matches partial object) - assertion fails', async () => {
+            const expectedPartialBody = {a: 1};
+            const actualBody = {a: 1, b: 2};
+            const testBody = {a: 1};
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path).withBodyThatContains(expectedPartialBody).willSucceed();
+            } else {
+                route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody).willSucceed();
+            }
+
+            await fetch(`http://localhost:${port}${path}`, {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify(actualBody),
+            });
+
+            expect(fakeServer.hasMade(route.call.withSpecificBody(testBody))).toEqual(false);
+        });
+
+        test('partial object restriction, assert on a specific object that does not match the partial object - exception', () => {
+            const expectedPartialBody = {a: 1};
+            const testBody = {b: 2};
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path).withBodyThatContains(expectedPartialBody).willSucceed();
+            } else {
+                route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody).willSucceed();
+            }
+
+            expect(() => route.call.withSpecificBody(testBody)).toThrow();
+        });
+
+        test('partial object restriction, passing something other than object to specific object method - exception', () => {
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path).withBodyThatContains({a: 1}).willSucceed();
+            } else {
+                route = fakeServer.post().to(path).withBodyThatContains({a: 1}).willSucceed();
+            }
+
+            expect(() => route.call.withSpecificBody('')).toThrow();
+        });
+
+        test('partial object restriction, assert on a specific string - exception', () => {
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path).withBodyThatContains({}).willSucceed();
+            } else {
+                route = fakeServer.post().to(path).withBodyThatContains({}).willSucceed();
+            }
+
+            expect(() => route.call.withBodyText('')).toThrow();
+        });
+
+        // route defined with object body restriction
+
+        test('object restriction, assert on a specific string - exception', () => {
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path).withBody({}).willSucceed();
+            } else {
+                route = fakeServer.post().to(path).withBody({}).willSucceed();
+            }
+
+            expect(() => route.call.withBodyText('')).toThrow();
+        });
+
+        test('object restriction, assert on a specific object (again) - exception', () => {
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path).withBody({}).willSucceed();
+            } else {
+                route = fakeServer.post().to(path).withBody({}).willSucceed();
+            }
+
+            expect(() => route.call.withSpecificBody({})).toThrow();
+        });
+
+        // route defined with no body restriction
+
+        test('no body restriction, assert on a specific string, application/json header, request body equals test string - assertion success', async () => {
+            let route;
+
+            if (useNewApi) {
+                route = fakeServer.post(path).willSucceed();
+            } else {
+                route = fakeServer.post().to(path).willSucceed();
+            }
+
+            const actualBody = {a: 1};
+            const testString = JSON.stringify({a: 1});
+
+            await fetch(`http://localhost:${port}${path}`, {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify(actualBody),
+            });
+
+            expect(fakeServer.hasMade(route.call.withBodyText(testString))).toEqual(true);
+        });
+
+        test('no body restriction, assert on a specific string, no application/json header, request body equals test string - assertion success', async () => {
+            let route;
+
+            if (useNewApi) {
+                route = fakeServer.post(path).willSucceed();
+            } else {
+                route = fakeServer.post().to(path).willSucceed();
+            }
+
+            const actualBody = 'abc';
+            const testString = 'abc';
+
+            await fetch(`http://localhost:${port}${path}`, {
+                method: 'POST',
+                headers: {'Content-Type': 'text/plain'},
+                body: actualBody,
+            });
+
+            expect(fakeServer.hasMade(route.call.withBodyText(testString))).toEqual(true);
+        });
+
+        test('no body restriction, assert on a specific object, application/json header request body equals test object - assertion success', async () => {
+            const actualBody = {a: 1, b: 2};
+            const testBody = {a: 1, b: 2};
+            let route;
+
+            if (useNewApi) {
+                route = fakeServer.post(path).willSucceed();
+            } else {
+                route = fakeServer.post().to(path).willSucceed();
+            }
+
+            await fetch(`http://localhost:${port}${path}`, {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify(actualBody),
+            });
+
+            expect(fakeServer.hasMade(route.call.withSpecificBody(testBody))).toEqual(true);
+        });
+
+        test('no body restriction, assert on a specific object, no application/json header, request body equals test object - assertion fails', async () => {
+            const actualBody = {a: 1, b: 2};
+            const testBody = {a: 1, b: 2};
+            let route;
+
+            if (useNewApi) {
+                route = fakeServer.post(path).willSucceed();
+            } else {
+                route = fakeServer.post().to(path).willSucceed();
+            }
+
+            await fetch(`http://localhost:${port}${path}`, {
+                method: 'POST',
+                headers: {'Content-Type': 'text/plain'},
+                body: JSON.stringify(actualBody),
+            });
+
+            expect(fakeServer.hasMade(route.call.withSpecificBody(testBody))).toEqual(false);
+        });
     });
-
-    expect(fakeServer.hasMade(route.call.withBodyText(testString))).toEqual(true);
-});
-
-test('regex restriction, assert on a specific string that matches the regex, request body does not equal test string (but matches regex) - assertion success', async () => {
-    const route = fakeServer.post().to(path).withBodyThatMatches(lettersRegex).willSucceed();
-    const actualBody = 'abc';
-    const testString = 'def';
-
-    await fetch(`http://localhost:${port}${path}`, {
-        method: 'POST',
-        headers: {'Content-Type': 'text/plain'},
-        body: actualBody,
-    });
-
-    expect(fakeServer.hasMade(route.call.withBodyText(testString))).toEqual(false);
-});
-
-test('regex restriction, assert on a specific string that does not match the regex - exception', () => {
-    const route = fakeServer.post().to(path).withBodyThatMatches(lettersRegex).willSucceed();
-
-    expect(() => route.call.withBodyText('123')).toThrow();
-});
-
-test('regex restriction, passing something other than string to specific string method - exception', () => {
-    const route = fakeServer.post().to(path).withBodyThatMatches(lettersRegex).willSucceed();
-
-    expect(() => route.call.withBodyText({} as string)).toThrow();
-});
-
-test('regex restriction, assert on a specific object - exception', () => {
-    const route = fakeServer.post().to(path).withBodyThatMatches(lettersRegex).willSucceed();
-
-    expect(() => route.call.withSpecificBody({})).toThrow();
-});
-
-// route defined with partial object body restriction
-
-test('partial object restriction, assert on a specific object that matches the partial object, request body equals test object - assertion success', async () => {
-    const expectedPartialBody = {a: 1};
-    const actualBody = {a: 1, b: 2};
-    const testBody = {a: 1, b: 2};
-    const route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody).willSucceed();
-
-    await fetch(`http://localhost:${port}${path}`, {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify(actualBody),
-    });
-
-    expect(fakeServer.hasMade(route.call.withSpecificBody(testBody))).toEqual(true);
-});
-
-test('partial object restriction, assert on a specific object that matches the partial object, request body does not equal test object (but matches partial object) - assertion fails', async () => {
-    const expectedPartialBody = {a: 1};
-    const actualBody = {a: 1, b: 2};
-    const testBody = {a: 1};
-    const route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody).willSucceed();
-
-    await fetch(`http://localhost:${port}${path}`, {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify(actualBody),
-    });
-
-    expect(fakeServer.hasMade(route.call.withSpecificBody(testBody))).toEqual(false);
-});
-
-test('partial object restriction, assert on a specific object that does not match the partial object - exception', () => {
-    const expectedPartialBody = {a: 1};
-    const testBody = {b: 2};
-    const route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody).willSucceed();
-
-    expect(() => route.call.withSpecificBody(testBody)).toThrow();
-});
-
-test('partial object restriction, passing something other than object to specific object method - exception', () => {
-    const route = fakeServer.post().to(path).withBodyThatContains({a: 1}).willSucceed();
-
-    expect(() => route.call.withSpecificBody('')).toThrow();
-});
-
-test('partial object restriction, assert on a specific string - exception', () => {
-    const route = fakeServer.post().to(path).withBodyThatContains({}).willSucceed();
-
-    expect(() => route.call.withBodyText('')).toThrow();
-});
-
-// route defined with object body restriction
-
-test('object restriction, assert on a specific string - exception', () => {
-    const route = fakeServer.post().to(path).withBody({}).willSucceed();
-
-    expect(() => route.call.withBodyText('')).toThrow();
-});
-
-test('object restriction, assert on a specific object (again) - exception', () => {
-    const route = fakeServer.post().to(path).withBody({}).willSucceed();
-
-    expect(() => route.call.withSpecificBody({})).toThrow();
-});
-
-// route defined with no body restriction
-
-test('no body restriction, assert on a specific string, application/json header, request body equals test string - assertion success', async () => {
-    const route = fakeServer.post().to(path).willSucceed();
-    const actualBody = {a: 1};
-    const testString = JSON.stringify({a: 1});
-
-    await fetch(`http://localhost:${port}${path}`, {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify(actualBody),
-    });
-
-    expect(fakeServer.hasMade(route.call.withBodyText(testString))).toEqual(true);
-});
-
-test('no body restriction, assert on a specific string, no application/json header, request body equals test string - assertion success', async () => {
-    const route = fakeServer.post().to(path).willSucceed();
-    const actualBody = 'abc';
-    const testString = 'abc';
-
-    await fetch(`http://localhost:${port}${path}`, {
-        method: 'POST',
-        headers: {'Content-Type': 'text/plain'},
-        body: actualBody,
-    });
-
-    expect(fakeServer.hasMade(route.call.withBodyText(testString))).toEqual(true);
-});
-
-test('no body restriction, assert on a specific object, application/json header request body equals test object - assertion success', async () => {
-    const actualBody = {a: 1, b: 2};
-    const testBody = {a: 1, b: 2};
-    const route = fakeServer.post().to(path).willSucceed();
-
-    await fetch(`http://localhost:${port}${path}`, {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify(actualBody),
-    });
-
-    expect(fakeServer.hasMade(route.call.withSpecificBody(testBody))).toEqual(true);
-});
-
-test('no body restriction, assert on a specific object, no application/json header, request body equals test object - assertion fails', async () => {
-    const actualBody = {a: 1, b: 2};
-    const testBody = {a: 1, b: 2};
-    const route = fakeServer.post().to(path).willSucceed();
-
-    await fetch(`http://localhost:${port}${path}`, {
-        method: 'POST',
-        headers: {'Content-Type': 'text/plain'},
-        body: JSON.stringify(actualBody),
-    });
-
-    expect(fakeServer.hasMade(route.call.withSpecificBody(testBody))).toEqual(false);
 });

--- a/__tests__/body-restrictions-on-assertion-tests.ts
+++ b/__tests__/body-restrictions-on-assertion-tests.ts
@@ -18,7 +18,7 @@ afterEach(() => {
 // route defined with regex body restriction
 
 test('regex restriction, assert on a specific string that matches the regex, request body equals test string - assertion success', async () => {
-    const route = fakeServer.http.post().to(path).withBodyThatMatches(lettersRegex).willSucceed();
+    const route = fakeServer.post().to(path).withBodyThatMatches(lettersRegex).willSucceed();
     const actualBody = 'abc';
     const testString = 'abc';
 
@@ -32,7 +32,7 @@ test('regex restriction, assert on a specific string that matches the regex, req
 });
 
 test('regex restriction, assert on a specific string that matches the regex, request body does not equal test string (but matches regex) - assertion success', async () => {
-    const route = fakeServer.http.post().to(path).withBodyThatMatches(lettersRegex).willSucceed();
+    const route = fakeServer.post().to(path).withBodyThatMatches(lettersRegex).willSucceed();
     const actualBody = 'abc';
     const testString = 'def';
 
@@ -46,19 +46,19 @@ test('regex restriction, assert on a specific string that matches the regex, req
 });
 
 test('regex restriction, assert on a specific string that does not match the regex - exception', () => {
-    const route = fakeServer.http.post().to(path).withBodyThatMatches(lettersRegex).willSucceed();
+    const route = fakeServer.post().to(path).withBodyThatMatches(lettersRegex).willSucceed();
 
     expect(() => route.call.withBodyText('123')).toThrow();
 });
 
 test('regex restriction, passing something other than string to specific string method - exception', () => {
-    const route = fakeServer.http.post().to(path).withBodyThatMatches(lettersRegex).willSucceed();
+    const route = fakeServer.post().to(path).withBodyThatMatches(lettersRegex).willSucceed();
 
     expect(() => route.call.withBodyText({} as string)).toThrow();
 });
 
 test('regex restriction, assert on a specific object - exception', () => {
-    const route = fakeServer.http.post().to(path).withBodyThatMatches(lettersRegex).willSucceed();
+    const route = fakeServer.post().to(path).withBodyThatMatches(lettersRegex).willSucceed();
 
     expect(() => route.call.withSpecificBody({})).toThrow();
 });
@@ -69,7 +69,7 @@ test('partial object restriction, assert on a specific object that matches the p
     const expectedPartialBody = {a: 1};
     const actualBody = {a: 1, b: 2};
     const testBody = {a: 1, b: 2};
-    const route = fakeServer.http.post().to(path).withBodyThatContains(expectedPartialBody).willSucceed();
+    const route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody).willSucceed();
 
     await fetch(`http://localhost:${port}${path}`, {
         method: 'POST',
@@ -84,7 +84,7 @@ test('partial object restriction, assert on a specific object that matches the p
     const expectedPartialBody = {a: 1};
     const actualBody = {a: 1, b: 2};
     const testBody = {a: 1};
-    const route = fakeServer.http.post().to(path).withBodyThatContains(expectedPartialBody).willSucceed();
+    const route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody).willSucceed();
 
     await fetch(`http://localhost:${port}${path}`, {
         method: 'POST',
@@ -98,19 +98,19 @@ test('partial object restriction, assert on a specific object that matches the p
 test('partial object restriction, assert on a specific object that does not match the partial object - exception', () => {
     const expectedPartialBody = {a: 1};
     const testBody = {b: 2};
-    const route = fakeServer.http.post().to(path).withBodyThatContains(expectedPartialBody).willSucceed();
+    const route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody).willSucceed();
 
     expect(() => route.call.withSpecificBody(testBody)).toThrow();
 });
 
 test('partial object restriction, passing something other than object to specific object method - exception', () => {
-    const route = fakeServer.http.post().to(path).withBodyThatContains({a: 1}).willSucceed();
+    const route = fakeServer.post().to(path).withBodyThatContains({a: 1}).willSucceed();
 
     expect(() => route.call.withSpecificBody('')).toThrow();
 });
 
 test('partial object restriction, assert on a specific string - exception', () => {
-    const route = fakeServer.http.post().to(path).withBodyThatContains({}).willSucceed();
+    const route = fakeServer.post().to(path).withBodyThatContains({}).willSucceed();
 
     expect(() => route.call.withBodyText('')).toThrow();
 });
@@ -118,13 +118,13 @@ test('partial object restriction, assert on a specific string - exception', () =
 // route defined with object body restriction
 
 test('object restriction, assert on a specific string - exception', () => {
-    const route = fakeServer.http.post().to(path).withBody({}).willSucceed();
+    const route = fakeServer.post().to(path).withBody({}).willSucceed();
 
     expect(() => route.call.withBodyText('')).toThrow();
 });
 
 test('object restriction, assert on a specific object (again) - exception', () => {
-    const route = fakeServer.http.post().to(path).withBody({}).willSucceed();
+    const route = fakeServer.post().to(path).withBody({}).willSucceed();
 
     expect(() => route.call.withSpecificBody({})).toThrow();
 });
@@ -132,7 +132,7 @@ test('object restriction, assert on a specific object (again) - exception', () =
 // route defined with no body restriction
 
 test('no body restriction, assert on a specific string, application/json header, request body equals test string - assertion success', async () => {
-    const route = fakeServer.http.post().to(path).willSucceed();
+    const route = fakeServer.post().to(path).willSucceed();
     const actualBody = {a: 1};
     const testString = JSON.stringify({a: 1});
 
@@ -146,7 +146,7 @@ test('no body restriction, assert on a specific string, application/json header,
 });
 
 test('no body restriction, assert on a specific string, no application/json header, request body equals test string - assertion success', async () => {
-    const route = fakeServer.http.post().to(path).willSucceed();
+    const route = fakeServer.post().to(path).willSucceed();
     const actualBody = 'abc';
     const testString = 'abc';
 
@@ -162,7 +162,7 @@ test('no body restriction, assert on a specific string, no application/json head
 test('no body restriction, assert on a specific object, application/json header request body equals test object - assertion success', async () => {
     const actualBody = {a: 1, b: 2};
     const testBody = {a: 1, b: 2};
-    const route = fakeServer.http.post().to(path).willSucceed();
+    const route = fakeServer.post().to(path).willSucceed();
 
     await fetch(`http://localhost:${port}${path}`, {
         method: 'POST',
@@ -176,7 +176,7 @@ test('no body restriction, assert on a specific object, application/json header 
 test('no body restriction, assert on a specific object, no application/json header, request body equals test object - assertion fails', async () => {
     const actualBody = {a: 1, b: 2};
     const testBody = {a: 1, b: 2};
-    const route = fakeServer.http.post().to(path).willSucceed();
+    const route = fakeServer.post().to(path).willSucceed();
 
     await fetch(`http://localhost:${port}${path}`, {
         method: 'POST',

--- a/__tests__/body-restrictions-on-route-definition-tests.ts
+++ b/__tests__/body-restrictions-on-route-definition-tests.ts
@@ -23,7 +23,7 @@ afterEach(() => {
 ].forEach(({method, defaultStatus}) => {
     describe(`Body Restriction on routes - ${method}`, () => {
         test('regex restriction, request body matches regex - match', async () => {
-            const route = fakeServer.http.post().to(path).withBodyThatMatches(lettersRegex)[method]();
+            const route = fakeServer.post().to(path).withBodyThatMatches(lettersRegex)[method]();
             const actualBody = 'abc';
 
             const res = await fetch(`http://localhost:${port}${path}`, {
@@ -41,7 +41,7 @@ afterEach(() => {
         });
 
         test('regex restriction, request has "application/json", request body matches regex - match', async () => {
-            const route = fakeServer.http.post().to(path).withBodyThatMatches('{.*}')[method]();
+            const route = fakeServer.post().to(path).withBodyThatMatches('{.*}')[method]();
             const actualBody = JSON.stringify({message: 'hi'});
 
             const res = await fetch(`http://localhost:${port}${path}`, {
@@ -55,7 +55,7 @@ afterEach(() => {
         });
 
         test('route defined with regex body restriction, request body does not match regex - no match', async () => {
-            const route = fakeServer.http.post().to(path).withBodyThatMatches(lettersRegex)[method]();
+            const route = fakeServer.post().to(path).withBodyThatMatches(lettersRegex)[method]();
             const actualBody = '123';
 
             const res = await fetch(`http://localhost:${port}${path}`, {
@@ -69,7 +69,7 @@ afterEach(() => {
         });
 
         test('route defined with regex body restriction, request has "application/json", request body does not match regex - no match', async () => {
-            const route = fakeServer.http.post().to(path).withBodyThatMatches(lettersRegex)[method]();
+            const route = fakeServer.post().to(path).withBodyThatMatches(lettersRegex)[method]();
             const actualBody = '123';
 
             const res = await fetch(`http://localhost:${port}${path}`, {
@@ -87,7 +87,7 @@ afterEach(() => {
         test('partial object restriction, request has "application/json", request body is equal to the body route object - match', async () => {
             const expectedPartialBody = {a: 1, b: 2};
             const actualBody = {a: 1, b: 2};
-            const route = fakeServer.http.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
+            const route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -102,7 +102,7 @@ afterEach(() => {
         test('partial object restriction, request has "application/json", request body is equal to the body route object but with different property order - match', async () => {
             const expectedPartialBody = {a: 1, b: 2};
             const actualBody = {b: 2, a: 1};
-            const route = fakeServer.http.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
+            const route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -117,7 +117,7 @@ afterEach(() => {
         test('partial object restriction, request has "application/json", request body is a superset of the body route object - match', async () => {
             const expectedPartialBody = {a: 1, b: 2};
             const actualBody = {a: 1, b: 2, c: 3};
-            const route = fakeServer.http.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
+            const route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -132,7 +132,7 @@ afterEach(() => {
         test('partial object restriction, request has "application/json", request body is not a superset of the body route object - no match', async () => {
             const expectedPartialBody = {a: 1, b: 2};
             const actualBody = {x: 1, y: 2};
-            const route = fakeServer.http.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
+            const route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -147,7 +147,7 @@ afterEach(() => {
         test('partial object restriction, request has "application/json", request body is not a superset of the body route object (missing property) - no match', async () => {
             const expectedPartialBody = {a: 1, b: 2};
             const actualBody = {a: 1};
-            const route = fakeServer.http.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
+            const route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -162,7 +162,7 @@ afterEach(() => {
         test('partial object restriction, request has "application/json", request body is not a superset of the body route object (different value) - no match', async () => {
             const expectedPartialBody = {a: 1, b: 2};
             const actualBody = {a: 1, b: 1};
-            const route = fakeServer.http.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
+            const route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -177,7 +177,7 @@ afterEach(() => {
         test('partial object restriction, request has "application/json", request body cannot be parsed to an object - no match', async () => {
             const expectedPartialBody = {a: 1, b: 2};
             const actualBody = 'abc';
-            const route = fakeServer.http.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
+            const route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -192,7 +192,7 @@ afterEach(() => {
         test('partial object restriction, request does not have "application/json" - no match', async () => {
             const expectedPartialBody = {a: 1, b: 2};
             const actualBody = {a: 1, b: 2};
-            const route = fakeServer.http.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
+            const route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -209,7 +209,7 @@ afterEach(() => {
         test('object restriction, request has "application/json", request body is equal to the body route object - match', async () => {
             const expectedBody = {a: 1, b: 2};
             const actualBody = {a: 1, b: 2};
-            const route = fakeServer.http.post().to(path).withBody(expectedBody)[method]();
+            const route = fakeServer.post().to(path).withBody(expectedBody)[method]();
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -224,7 +224,7 @@ afterEach(() => {
         test('object restriction, request has "application/json", request body is equal to the body route object but with different property order - match', async () => {
             const expectedBody = {a: 1, b: 2};
             const actualBody = {b: 2, a: 1};
-            const route = fakeServer.http.post().to(path).withBody(expectedBody)[method]();
+            const route = fakeServer.post().to(path).withBody(expectedBody)[method]();
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -239,7 +239,7 @@ afterEach(() => {
         test('object restriction, request has "application/json", request body is a superset of the body route object - no match', async () => {
             const expectedBody = {a: 1, b: 2};
             const actualBody = {a: 1, b: 2, c: 3};
-            const route = fakeServer.http.post().to(path).withBody(expectedBody)[method]();
+            const route = fakeServer.post().to(path).withBody(expectedBody)[method]();
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -254,7 +254,7 @@ afterEach(() => {
         test('object restriction, request has "application/json", request body is a subset of the body route object - no match', async () => {
             const expectedBody = {a: 1, b: 2};
             const actualBody = {a: 1};
-            const route = fakeServer.http.post().to(path).withBody(expectedBody)[method]();
+            const route = fakeServer.post().to(path).withBody(expectedBody)[method]();
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -269,7 +269,7 @@ afterEach(() => {
         test('object restriction, request has "application/json", request body is different than the body route object - no match', async () => {
             const expectedBody = {a: 1, b: 2};
             const actualBody = {a: 1, b: 1};
-            const route = fakeServer.http.post().to(path).withBody(expectedBody)[method]();
+            const route = fakeServer.post().to(path).withBody(expectedBody)[method]();
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -284,7 +284,7 @@ afterEach(() => {
         test('object restriction, request has "application/json", request body cannot be parsed to an object - no match', async () => {
             const expectedBody = {a: 1, b: 2};
             const actualBody = 'abc';
-            const route = fakeServer.http.post().to(path).withBody(expectedBody)[method]();
+            const route = fakeServer.post().to(path).withBody(expectedBody)[method]();
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -299,7 +299,7 @@ afterEach(() => {
         test('object restriction, request does not have "application/json" - no match', async () => {
             const expectedBody = {a: 1, b: 2};
             const actualBody = {a: 1, b: 2};
-            const route = fakeServer.http.post().to(path).withBody(expectedBody)[method]();
+            const route = fakeServer.post().to(path).withBody(expectedBody)[method]();
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -314,7 +314,7 @@ afterEach(() => {
         // route defined with no body restriction
 
         test('no body restriction, request body empty - match', async () => {
-            const route = fakeServer.http.post().to(path)[method]();
+            const route = fakeServer.post().to(path)[method]();
 
             const res = await fetch(`http://localhost:${port}${path}`, {method: 'POST'});
 
@@ -323,7 +323,7 @@ afterEach(() => {
         });
 
         test('no body restriction, request has "application/json", request body empty - match', async () => {
-            const route = fakeServer.http.post().to(path)[method]();
+            const route = fakeServer.post().to(path)[method]();
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -335,7 +335,7 @@ afterEach(() => {
         });
 
         test('no body restriction, request body not empty - match', async () => {
-            const route = fakeServer.http.post().to(path)[method]();
+            const route = fakeServer.post().to(path)[method]();
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -348,7 +348,7 @@ afterEach(() => {
         });
 
         test('no body restriction, request has "application/json", request body not empty - match', async () => {
-            const route = fakeServer.http.post().to(path)[method]();
+            const route = fakeServer.post().to(path)[method]();
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -361,9 +361,9 @@ afterEach(() => {
         });
 
         test('defining 2 routes with the same path with restrictions, make a call that matches only one - success + match', async () => {
-            const route1 = fakeServer.http.post().to(path).withBodyThatContains({c: 3, d: 4})[method]();
+            const route1 = fakeServer.post().to(path).withBodyThatContains({c: 3, d: 4})[method]();
 
-            const route2 = fakeServer.http.post().to(path).withBodyThatContains({a: 1, b: 2})[method]();
+            const route2 = fakeServer.post().to(path).withBodyThatContains({a: 1, b: 2})[method]();
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',

--- a/__tests__/body-restrictions-on-route-definition-tests.ts
+++ b/__tests__/body-restrictions-on-route-definition-tests.ts
@@ -20,10 +20,18 @@ afterEach(() => {
 [
     {method: 'willSucceed', defaultStatus: 200},
     {method: 'willFail', defaultStatus: 500},
-].forEach(({method, defaultStatus}) => {
+    {method: 'willSucceed', defaultStatus: 200, useNewApi: true},
+    {method: 'willFail', defaultStatus: 500, useNewApi: true},
+].forEach(({method, defaultStatus, useNewApi}) => {
     describe(`Body Restriction on routes - ${method}`, () => {
         test('regex restriction, request body matches regex - match', async () => {
-            const route = fakeServer.post().to(path).withBodyThatMatches(lettersRegex)[method]();
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path).withBodyThatMatches(lettersRegex)[method]();
+            } else {
+                route = fakeServer.post().to(path).withBodyThatMatches(lettersRegex)[method]();
+            }
+
             const actualBody = 'abc';
 
             const res = await fetch(`http://localhost:${port}${path}`, {
@@ -41,7 +49,13 @@ afterEach(() => {
         });
 
         test('regex restriction, request has "application/json", request body matches regex - match', async () => {
-            const route = fakeServer.post().to(path).withBodyThatMatches('{.*}')[method]();
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path).withBodyThatMatches('{.*}')[method]();
+            } else {
+                route = fakeServer.post().to(path).withBodyThatMatches('{.*}')[method]();
+            }
+
             const actualBody = JSON.stringify({message: 'hi'});
 
             const res = await fetch(`http://localhost:${port}${path}`, {
@@ -55,7 +69,13 @@ afterEach(() => {
         });
 
         test('route defined with regex body restriction, request body does not match regex - no match', async () => {
-            const route = fakeServer.post().to(path).withBodyThatMatches(lettersRegex)[method]();
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path).withBodyThatMatches(lettersRegex)[method]();
+            } else {
+                route = fakeServer.post().to(path).withBodyThatMatches(lettersRegex)[method]();
+            }
+
             const actualBody = '123';
 
             const res = await fetch(`http://localhost:${port}${path}`, {
@@ -69,7 +89,13 @@ afterEach(() => {
         });
 
         test('route defined with regex body restriction, request has "application/json", request body does not match regex - no match', async () => {
-            const route = fakeServer.post().to(path).withBodyThatMatches(lettersRegex)[method]();
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path).withBodyThatMatches(lettersRegex)[method]();
+            } else {
+                route = fakeServer.post().to(path).withBodyThatMatches(lettersRegex)[method]();
+            }
+
             const actualBody = '123';
 
             const res = await fetch(`http://localhost:${port}${path}`, {
@@ -87,7 +113,13 @@ afterEach(() => {
         test('partial object restriction, request has "application/json", request body is equal to the body route object - match', async () => {
             const expectedPartialBody = {a: 1, b: 2};
             const actualBody = {a: 1, b: 2};
-            const route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
+
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path).withBodyThatContains(expectedPartialBody)[method]();
+            } else {
+                route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
+            }
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -102,7 +134,13 @@ afterEach(() => {
         test('partial object restriction, request has "application/json", request body is equal to the body route object but with different property order - match', async () => {
             const expectedPartialBody = {a: 1, b: 2};
             const actualBody = {b: 2, a: 1};
-            const route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
+
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path).withBodyThatContains(expectedPartialBody)[method]();
+            } else {
+                route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
+            }
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -117,7 +155,13 @@ afterEach(() => {
         test('partial object restriction, request has "application/json", request body is a superset of the body route object - match', async () => {
             const expectedPartialBody = {a: 1, b: 2};
             const actualBody = {a: 1, b: 2, c: 3};
-            const route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
+
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path).withBodyThatContains(expectedPartialBody)[method]();
+            } else {
+                route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
+            }
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -132,7 +176,13 @@ afterEach(() => {
         test('partial object restriction, request has "application/json", request body is not a superset of the body route object - no match', async () => {
             const expectedPartialBody = {a: 1, b: 2};
             const actualBody = {x: 1, y: 2};
-            const route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
+
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path).withBodyThatContains(expectedPartialBody)[method]();
+            } else {
+                route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
+            }
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -147,7 +197,12 @@ afterEach(() => {
         test('partial object restriction, request has "application/json", request body is not a superset of the body route object (missing property) - no match', async () => {
             const expectedPartialBody = {a: 1, b: 2};
             const actualBody = {a: 1};
-            const route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path).withBodyThatContains(expectedPartialBody)[method]();
+            } else {
+                route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
+            }
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -162,7 +217,13 @@ afterEach(() => {
         test('partial object restriction, request has "application/json", request body is not a superset of the body route object (different value) - no match', async () => {
             const expectedPartialBody = {a: 1, b: 2};
             const actualBody = {a: 1, b: 1};
-            const route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
+
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path).withBodyThatContains(expectedPartialBody)[method]();
+            } else {
+                route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
+            }
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -177,7 +238,12 @@ afterEach(() => {
         test('partial object restriction, request has "application/json", request body cannot be parsed to an object - no match', async () => {
             const expectedPartialBody = {a: 1, b: 2};
             const actualBody = 'abc';
-            const route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path).withBodyThatContains(expectedPartialBody)[method]();
+            } else {
+                route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
+            }
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -192,7 +258,12 @@ afterEach(() => {
         test('partial object restriction, request does not have "application/json" - no match', async () => {
             const expectedPartialBody = {a: 1, b: 2};
             const actualBody = {a: 1, b: 2};
-            const route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path).withBodyThatContains(expectedPartialBody)[method]();
+            } else {
+                route = fakeServer.post().to(path).withBodyThatContains(expectedPartialBody)[method]();
+            }
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -209,7 +280,13 @@ afterEach(() => {
         test('object restriction, request has "application/json", request body is equal to the body route object - match', async () => {
             const expectedBody = {a: 1, b: 2};
             const actualBody = {a: 1, b: 2};
-            const route = fakeServer.post().to(path).withBody(expectedBody)[method]();
+
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path).withBody(expectedBody)[method]();
+            } else {
+                route = fakeServer.post().to(path).withBody(expectedBody)[method]();
+            }
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -224,7 +301,12 @@ afterEach(() => {
         test('object restriction, request has "application/json", request body is equal to the body route object but with different property order - match', async () => {
             const expectedBody = {a: 1, b: 2};
             const actualBody = {b: 2, a: 1};
-            const route = fakeServer.post().to(path).withBody(expectedBody)[method]();
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path).withBody(expectedBody)[method]();
+            } else {
+                route = fakeServer.post().to(path).withBody(expectedBody)[method]();
+            }
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -239,7 +321,12 @@ afterEach(() => {
         test('object restriction, request has "application/json", request body is a superset of the body route object - no match', async () => {
             const expectedBody = {a: 1, b: 2};
             const actualBody = {a: 1, b: 2, c: 3};
-            const route = fakeServer.post().to(path).withBody(expectedBody)[method]();
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path).withBody(expectedBody)[method]();
+            } else {
+                route = fakeServer.post().to(path).withBody(expectedBody)[method]();
+            }
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -254,7 +341,12 @@ afterEach(() => {
         test('object restriction, request has "application/json", request body is a subset of the body route object - no match', async () => {
             const expectedBody = {a: 1, b: 2};
             const actualBody = {a: 1};
-            const route = fakeServer.post().to(path).withBody(expectedBody)[method]();
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path).withBody(expectedBody)[method]();
+            } else {
+                route = fakeServer.post().to(path).withBody(expectedBody)[method]();
+            }
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -269,7 +361,12 @@ afterEach(() => {
         test('object restriction, request has "application/json", request body is different than the body route object - no match', async () => {
             const expectedBody = {a: 1, b: 2};
             const actualBody = {a: 1, b: 1};
-            const route = fakeServer.post().to(path).withBody(expectedBody)[method]();
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path).withBody(expectedBody)[method]();
+            } else {
+                route = fakeServer.post().to(path).withBody(expectedBody)[method]();
+            }
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -284,7 +381,12 @@ afterEach(() => {
         test('object restriction, request has "application/json", request body cannot be parsed to an object - no match', async () => {
             const expectedBody = {a: 1, b: 2};
             const actualBody = 'abc';
-            const route = fakeServer.post().to(path).withBody(expectedBody)[method]();
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path).withBody(expectedBody)[method]();
+            } else {
+                route = fakeServer.post().to(path).withBody(expectedBody)[method]();
+            }
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -299,7 +401,12 @@ afterEach(() => {
         test('object restriction, request does not have "application/json" - no match', async () => {
             const expectedBody = {a: 1, b: 2};
             const actualBody = {a: 1, b: 2};
-            const route = fakeServer.post().to(path).withBody(expectedBody)[method]();
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path).withBody(expectedBody)[method]();
+            } else {
+                route = fakeServer.post().to(path).withBody(expectedBody)[method]();
+            }
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -314,7 +421,12 @@ afterEach(() => {
         // route defined with no body restriction
 
         test('no body restriction, request body empty - match', async () => {
-            const route = fakeServer.post().to(path)[method]();
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path)[method]();
+            } else {
+                route = fakeServer.post().to(path)[method]();
+            }
 
             const res = await fetch(`http://localhost:${port}${path}`, {method: 'POST'});
 
@@ -323,7 +435,12 @@ afterEach(() => {
         });
 
         test('no body restriction, request has "application/json", request body empty - match', async () => {
-            const route = fakeServer.post().to(path)[method]();
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path)[method]();
+            } else {
+                route = fakeServer.post().to(path)[method]();
+            }
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -335,7 +452,12 @@ afterEach(() => {
         });
 
         test('no body restriction, request body not empty - match', async () => {
-            const route = fakeServer.post().to(path)[method]();
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path)[method]();
+            } else {
+                route = fakeServer.post().to(path)[method]();
+            }
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -348,7 +470,12 @@ afterEach(() => {
         });
 
         test('no body restriction, request has "application/json", request body not empty - match', async () => {
-            const route = fakeServer.post().to(path)[method]();
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(path)[method]();
+            } else {
+                route = fakeServer.post().to(path)[method]();
+            }
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',
@@ -361,9 +488,15 @@ afterEach(() => {
         });
 
         test('defining 2 routes with the same path with restrictions, make a call that matches only one - success + match', async () => {
-            const route1 = fakeServer.post().to(path).withBodyThatContains({c: 3, d: 4})[method]();
-
-            const route2 = fakeServer.post().to(path).withBodyThatContains({a: 1, b: 2})[method]();
+            let route1;
+            let route2;
+            if (useNewApi) {
+                route1 = fakeServer.post(path).withBodyThatContains({c: 3, d: 4})[method]();
+                route2 = fakeServer.post(path).withBodyThatContains({a: 1, b: 2})[method]();
+            } else {
+                route1 = fakeServer.post().to(path).withBodyThatContains({c: 3, d: 4})[method]();
+                route2 = fakeServer.post().to(path).withBodyThatContains({a: 1, b: 2})[method]();
+            }
 
             const res = await fetch(`http://localhost:${port}${path}`, {
                 method: 'POST',

--- a/__tests__/mocking-response-elements.ts
+++ b/__tests__/mocking-response-elements.ts
@@ -15,31 +15,45 @@ afterEach(() => {
     fakeServer.stop();
 });
 
-describe('Route Matching - willReturn Response Elements', () => {
-    test('GET route defined with mocked body and response headers', async () => {
-        const path = '/somePath';
-        const route = fakeServer.get().to(path).willReturn({name: 'Cloud'}, 200, {imontop: 'Of The World'});
+[{useNewApi: true}, {useNewApi: false}].forEach(({useNewApi}) => {
+    describe('Route Matching - willReturn Response Elements', () => {
+        test('GET route defined with mocked body and response headers', async () => {
+            const path = '/somePath';
 
-        const res = await fetch(`http://localhost:${port}${path}`, {method: 'GET'});
-        const body = await res.json();
+            let route;
+            if (useNewApi) {
+                route = fakeServer.get(path).willReturn({name: 'Cloud'}, 200, {imontop: 'Of The World'});
+            } else {
+                route = fakeServer.get().to(path).willReturn({name: 'Cloud'}, 200, {imontop: 'Of The World'});
+            }
 
-        expect(body.name).toEqual('Cloud');
-        expect(res.status).toEqual(200);
-        expect(res.headers.get('imontop')).toEqual('Of The World');
-        expect(fakeServer.hasMade(route.call)).toEqual(true);
-    });
+            const res = await fetch(`http://localhost:${port}${path}`, {method: 'GET'});
+            const body = await res.json();
 
-    test('GET route defined with response as stream', async () => {
-        const stringTobeStreamed = 'Rivers are huge Streams';
-        const bodyAsStream = intoStream(stringTobeStreamed);
-        const path = '/somePath';
-        const route = fakeServer.get().to(path).willReturn(bodyAsStream);
+            expect(body.name).toEqual('Cloud');
+            expect(res.status).toEqual(200);
+            expect(res.headers.get('imontop')).toEqual('Of The World');
+            expect(fakeServer.hasMade(route.call)).toEqual(true);
+        });
 
-        const res = await fetch(`http://localhost:${port}${path}`, {method: 'GET'});
-        expect(res.headers.get('content-type')).toEqual('application/octet-stream');
-        expect(res.status).toEqual(200);
-        expect(fakeServer.hasMade(route.call)).toEqual(true);
-        const body = await getStream(res.body);
-        expect(body).toEqual(stringTobeStreamed);
+        test('GET route defined with response as stream', async () => {
+            const stringTobeStreamed = 'Rivers are huge Streams';
+            const bodyAsStream = intoStream(stringTobeStreamed);
+            const path = '/somePath';
+
+            let route;
+            if (useNewApi) {
+                route = fakeServer.get(path).willReturn(bodyAsStream);
+            } else {
+                route = fakeServer.get().to(path).willReturn(bodyAsStream);
+            }
+
+            const res = await fetch(`http://localhost:${port}${path}`, {method: 'GET'});
+            expect(res.headers.get('content-type')).toEqual('application/octet-stream');
+            expect(res.status).toEqual(200);
+            expect(fakeServer.hasMade(route.call)).toEqual(true);
+            const body = await getStream(res.body);
+            expect(body).toEqual(stringTobeStreamed);
+        });
     });
 });

--- a/__tests__/mocking-response-elements.ts
+++ b/__tests__/mocking-response-elements.ts
@@ -18,7 +18,7 @@ afterEach(() => {
 describe('Route Matching - willReturn Response Elements', () => {
     test('GET route defined with mocked body and response headers', async () => {
         const path = '/somePath';
-        const route = fakeServer.http.get().to(path).willReturn({name: 'Cloud'}, 200, {imontop: 'Of The World'});
+        const route = fakeServer.get().to(path).willReturn({name: 'Cloud'}, 200, {imontop: 'Of The World'});
 
         const res = await fetch(`http://localhost:${port}${path}`, {method: 'GET'});
         const body = await res.json();
@@ -33,7 +33,7 @@ describe('Route Matching - willReturn Response Elements', () => {
         const stringTobeStreamed = 'Rivers are huge Streams';
         const bodyAsStream = intoStream(stringTobeStreamed);
         const path = '/somePath';
-        const route = fakeServer.http.get().to(path).willReturn(bodyAsStream);
+        const route = fakeServer.get().to(path).willReturn(bodyAsStream);
 
         const res = await fetch(`http://localhost:${port}${path}`, {method: 'GET'});
         expect(res.headers.get('content-type')).toEqual('application/octet-stream');

--- a/__tests__/route-matching-general-tests.ts
+++ b/__tests__/route-matching-general-tests.ts
@@ -20,7 +20,7 @@ afterEach(() => {
     describe(`Route Matching - ${method}`, () => {
         test('GET route defined, one call matches and two dont, callsMade returns only the matching call', async () => {
             const path = '/somePath';
-            const route = fakeServer.http.get().to(path)[method]();
+            const route = fakeServer.get().to(path)[method]();
 
             await fetch(`http://localhost:${port}${path}`, {method: 'GET'});
             await fetch(`http://localhost:${port}${path}`, {method: 'PUT'});
@@ -31,7 +31,7 @@ afterEach(() => {
 
         test('GET route defined and called - match', async () => {
             const path = '/somePath';
-            const route = fakeServer.http.get().to(path)[method]();
+            const route = fakeServer.get().to(path)[method]();
 
             const res = await fetch(`http://localhost:${port}${path}`, {method: 'GET'});
 
@@ -42,7 +42,7 @@ afterEach(() => {
         test('GET route with query params - match', async () => {
             const path = '/someQueryPath';
             const queryObject = {k1: 'v1', k2: 'v2'};
-            const route = fakeServer.http.get().to(path).withQueryParams(queryObject)[method]();
+            const route = fakeServer.get().to(path).withQueryParams(queryObject)[method]();
 
             const queryParams = '?k1=v1&k2=v2';
 
@@ -55,7 +55,7 @@ afterEach(() => {
         test('GET route with extra query params - no match', async () => {
             const path = '/someQueryPath';
             const queryObject = {k1: 'v1'};
-            const route = fakeServer.http.get().to(path).withQueryParams(queryObject)[method]();
+            const route = fakeServer.get().to(path).withQueryParams(queryObject)[method]();
 
             const queryParams = '?k1=v1&k2=v2';
 
@@ -68,7 +68,7 @@ afterEach(() => {
         test('GET route with wrong query params - no match', async () => {
             const path = '/someQueryPath';
             const queryObject = {k1: 'v1', k2: 'v2'};
-            const route = fakeServer.http.get().to(path).withQueryParams(queryObject)[method]();
+            const route = fakeServer.get().to(path).withQueryParams(queryObject)[method]();
 
             const wrongQueryParams = '?k1=v1&k3=v3';
 
@@ -81,7 +81,7 @@ afterEach(() => {
         test('GET route with partial query params - no match', async () => {
             const path = '/someQueryPath';
             const queryObject = {k1: 'v1', k2: 'v2'};
-            const route = fakeServer.http.get().to(path).withQueryParams(queryObject)[method]();
+            const route = fakeServer.get().to(path).withQueryParams(queryObject)[method]();
 
             const wrongQueryParams = '?k1=v1';
 
@@ -94,7 +94,7 @@ afterEach(() => {
         test('GET route with no query params and with query restrictions - no match', async () => {
             const path = '/someQueryPath';
             const queryObject = {k1: 'v1', k2: 'v2'};
-            const route = fakeServer.http.get().to(path).withQueryParams(queryObject)[method]();
+            const route = fakeServer.get().to(path).withQueryParams(queryObject)[method]();
 
             const res = await fetch(`http://localhost:${port}${path}`, {method: 'GET'});
 
@@ -104,7 +104,7 @@ afterEach(() => {
 
         test('GET route with query paraysm without specifying query restrictions -  match', async () => {
             const path = '/someQueryPath';
-            const route = fakeServer.http.get().to(path)[method]();
+            const route = fakeServer.get().to(path)[method]();
 
             const queryParams = '?k1=v1&k3=v3';
 
@@ -116,7 +116,7 @@ afterEach(() => {
 
         test('DELETE route defined and called - match', async () => {
             const path = '/somePath';
-            const route = fakeServer.http.delete().to(path)[method]();
+            const route = fakeServer.delete().to(path)[method]();
 
             const res = await fetch(`http://localhost:${port}${path}`, {method: 'DELETE'});
 
@@ -126,7 +126,7 @@ afterEach(() => {
 
         test('PUT route defined and called - match', async () => {
             const path = '/somePath';
-            const route = fakeServer.http.put().to(path)[method]();
+            const route = fakeServer.put().to(path)[method]();
 
             const res = await fetch(`http://localhost:${port}${path}`, {method: 'PUT'});
 
@@ -136,7 +136,7 @@ afterEach(() => {
 
         test('PATCH route defined and called - match', async () => {
             const path = '/somePath';
-            const route = fakeServer.http.patch().to(path)[method]();
+            const route = fakeServer.patch().to(path)[method]();
 
             const res = await fetch(`http://localhost:${port}${path}`, {method: 'PATCH'});
 
@@ -146,7 +146,7 @@ afterEach(() => {
 
         test('route defined and not called - no match', () => {
             const path = '/somePath';
-            const route = fakeServer.http.get().to(path)[method]();
+            const route = fakeServer.get().to(path)[method]();
 
             expect(fakeServer.hasMade(route.call)).toEqual(false);
         });
@@ -154,7 +154,7 @@ afterEach(() => {
         test('route defined with path regex - asserting on specific path that matches the regex - assertion success', async () => {
             const pathRegex = '/[a-zA-Z]+$';
             const actualPath = '/somePathThatMatchesTheRegex';
-            const route = fakeServer.http.get().to(pathRegex)[method]();
+            const route = fakeServer.get().to(pathRegex)[method]();
 
             const res = await fetch(`http://localhost:${port}${actualPath}`, {method: 'GET'});
 
@@ -165,7 +165,7 @@ afterEach(() => {
         test('route defined with path regex - asserting on specific path that does not match the path regex - throws', () => {
             const pathRegex = '/[0-9]+$';
             const pathThatDoesNotMatchTheRegex = '/pathThatDoesNotMatchTheRegex';
-            const route = fakeServer.http.get().to(pathRegex)[method]();
+            const route = fakeServer.get().to(pathRegex)[method]();
 
             expect(() => route.call.withPath(pathThatDoesNotMatchTheRegex)).toThrow();
         });
@@ -175,7 +175,7 @@ afterEach(() => {
             const actualPath = '/somePath';
             const bodyRegex = '[0-9]+$';
             const actualBody = '123';
-            const route = fakeServer.http.post().to(pathRegex).withBodyThatMatches(bodyRegex)[method]();
+            const route = fakeServer.post().to(pathRegex).withBodyThatMatches(bodyRegex)[method]();
 
             const res = await fetch(`http://localhost:${port}${actualPath}`, {
                 method: 'POST',
@@ -193,7 +193,7 @@ afterEach(() => {
 describe('Route Matching - willReturn', () => {
     test('GET route defined with default status code and called - match', async () => {
         const path = '/somePath';
-        const route = fakeServer.http.get().to(path).willReturn({name: 'Morty'});
+        const route = fakeServer.get().to(path).willReturn({name: 'Morty'});
 
         const res = await fetch(`http://localhost:${port}${path}`, {method: 'GET'});
         const body = await res.json();
@@ -205,7 +205,7 @@ describe('Route Matching - willReturn', () => {
 
     test('GET route defined with custom status code and called - match', async () => {
         const path = '/somePath';
-        const route = fakeServer.http.get().to(path).willReturn({name: 'Teapot'}, 418);
+        const route = fakeServer.get().to(path).willReturn({name: 'Teapot'}, 418);
 
         const res = await fetch(`http://localhost:${port}${path}`, {method: 'GET'});
         const body = await res.json();
@@ -221,7 +221,7 @@ describe('Route Matching - willReturn', () => {
         const bodyRegex = '[0-9]+$';
         const actualBody = '123';
         const requestBody = 'body as string';
-        const route = fakeServer.http.post().to(pathRegex).withBodyThatMatches(bodyRegex).willReturn(requestBody, 300);
+        const route = fakeServer.post().to(pathRegex).withBodyThatMatches(bodyRegex).willReturn(requestBody, 300);
 
         const res = await fetch(`http://localhost:${port}${actualPath}`, {
             method: 'POST',

--- a/__tests__/route-matching-general-tests.ts
+++ b/__tests__/route-matching-general-tests.ts
@@ -14,13 +14,20 @@ afterEach(() => {
 });
 
 [
-    {method: 'willSucceed', defaultStatus: 200},
-    {method: 'willFail', defaultStatus: 500},
-].forEach(({method, defaultStatus}) => {
+    {method: 'willSucceed', defaultStatus: 200, useNewApi: false},
+    {method: 'willFail', defaultStatus: 500, useNewApi: false},
+    {method: 'willSucceed', defaultStatus: 200, useNewApi: true},
+    {method: 'willFail', defaultStatus: 500, useNewApi: true},
+].forEach(({method, defaultStatus, useNewApi}) => {
     describe(`Route Matching - ${method}`, () => {
         test('GET route defined, one call matches and two dont, callsMade returns only the matching call', async () => {
             const path = '/somePath';
-            const route = fakeServer.get().to(path)[method]();
+            let route;
+            if (useNewApi) {
+                route = fakeServer.get(path)[method]();
+            } else {
+                route = fakeServer.get().to(path)[method]();
+            }
 
             await fetch(`http://localhost:${port}${path}`, {method: 'GET'});
             await fetch(`http://localhost:${port}${path}`, {method: 'PUT'});
@@ -31,7 +38,12 @@ afterEach(() => {
 
         test('GET route defined and called - match', async () => {
             const path = '/somePath';
-            const route = fakeServer.get().to(path)[method]();
+            let route;
+            if (useNewApi) {
+                route = fakeServer.get(path)[method]();
+            } else {
+                route = fakeServer.get().to(path)[method]();
+            }
 
             const res = await fetch(`http://localhost:${port}${path}`, {method: 'GET'});
 
@@ -42,7 +54,13 @@ afterEach(() => {
         test('GET route with query params - match', async () => {
             const path = '/someQueryPath';
             const queryObject = {k1: 'v1', k2: 'v2'};
-            const route = fakeServer.get().to(path).withQueryParams(queryObject)[method]();
+
+            let route;
+            if (useNewApi) {
+                route = fakeServer.get(path).withQueryParams(queryObject)[method]();
+            } else {
+                route = fakeServer.get().to(path).withQueryParams(queryObject)[method]();
+            }
 
             const queryParams = '?k1=v1&k2=v2';
 
@@ -55,7 +73,12 @@ afterEach(() => {
         test('GET route with extra query params - no match', async () => {
             const path = '/someQueryPath';
             const queryObject = {k1: 'v1'};
-            const route = fakeServer.get().to(path).withQueryParams(queryObject)[method]();
+            let route;
+            if (useNewApi) {
+                route = fakeServer.get(path).withQueryParams(queryObject)[method]();
+            } else {
+                route = fakeServer.get().to(path).withQueryParams(queryObject)[method]();
+            }
 
             const queryParams = '?k1=v1&k2=v2';
 
@@ -68,7 +91,12 @@ afterEach(() => {
         test('GET route with wrong query params - no match', async () => {
             const path = '/someQueryPath';
             const queryObject = {k1: 'v1', k2: 'v2'};
-            const route = fakeServer.get().to(path).withQueryParams(queryObject)[method]();
+            let route;
+            if (useNewApi) {
+                route = fakeServer.get(path).withQueryParams(queryObject)[method]();
+            } else {
+                route = fakeServer.get().to(path).withQueryParams(queryObject)[method]();
+            }
 
             const wrongQueryParams = '?k1=v1&k3=v3';
 
@@ -81,7 +109,12 @@ afterEach(() => {
         test('GET route with partial query params - no match', async () => {
             const path = '/someQueryPath';
             const queryObject = {k1: 'v1', k2: 'v2'};
-            const route = fakeServer.get().to(path).withQueryParams(queryObject)[method]();
+            let route;
+            if (useNewApi) {
+                route = fakeServer.get(path).withQueryParams(queryObject)[method]();
+            } else {
+                route = fakeServer.get().to(path).withQueryParams(queryObject)[method]();
+            }
 
             const wrongQueryParams = '?k1=v1';
 
@@ -94,7 +127,12 @@ afterEach(() => {
         test('GET route with no query params and with query restrictions - no match', async () => {
             const path = '/someQueryPath';
             const queryObject = {k1: 'v1', k2: 'v2'};
-            const route = fakeServer.get().to(path).withQueryParams(queryObject)[method]();
+            let route;
+            if (useNewApi) {
+                route = fakeServer.get(path).withQueryParams(queryObject)[method]();
+            } else {
+                route = fakeServer.get().to(path).withQueryParams(queryObject)[method]();
+            }
 
             const res = await fetch(`http://localhost:${port}${path}`, {method: 'GET'});
 
@@ -104,7 +142,13 @@ afterEach(() => {
 
         test('GET route with query paraysm without specifying query restrictions -  match', async () => {
             const path = '/someQueryPath';
-            const route = fakeServer.get().to(path)[method]();
+
+            let route;
+            if (useNewApi) {
+                route = fakeServer.get()[method]();
+            } else {
+                route = fakeServer.get().to(path)[method]();
+            }
 
             const queryParams = '?k1=v1&k3=v3';
 
@@ -116,7 +160,13 @@ afterEach(() => {
 
         test('DELETE route defined and called - match', async () => {
             const path = '/somePath';
-            const route = fakeServer.delete().to(path)[method]();
+
+            let route;
+            if (useNewApi) {
+                route = fakeServer.delete(path)[method]();
+            } else {
+                route = fakeServer.delete().to(path)[method]();
+            }
 
             const res = await fetch(`http://localhost:${port}${path}`, {method: 'DELETE'});
 
@@ -126,7 +176,13 @@ afterEach(() => {
 
         test('PUT route defined and called - match', async () => {
             const path = '/somePath';
-            const route = fakeServer.put().to(path)[method]();
+
+            let route;
+            if (useNewApi) {
+                route = fakeServer.put(path)[method]();
+            } else {
+                route = fakeServer.put().to(path)[method]();
+            }
 
             const res = await fetch(`http://localhost:${port}${path}`, {method: 'PUT'});
 
@@ -136,7 +192,13 @@ afterEach(() => {
 
         test('PATCH route defined and called - match', async () => {
             const path = '/somePath';
-            const route = fakeServer.patch().to(path)[method]();
+
+            let route;
+            if (useNewApi) {
+                route = fakeServer.patch(path)[method]();
+            } else {
+                route = fakeServer.patch().to(path)[method]();
+            }
 
             const res = await fetch(`http://localhost:${port}${path}`, {method: 'PATCH'});
 
@@ -146,7 +208,13 @@ afterEach(() => {
 
         test('route defined and not called - no match', () => {
             const path = '/somePath';
-            const route = fakeServer.get().to(path)[method]();
+
+            let route;
+            if (useNewApi) {
+                route = fakeServer.get(path)[method]();
+            } else {
+                route = fakeServer.get().to(path)[method]();
+            }
 
             expect(fakeServer.hasMade(route.call)).toEqual(false);
         });
@@ -154,7 +222,13 @@ afterEach(() => {
         test('route defined with path regex - asserting on specific path that matches the regex - assertion success', async () => {
             const pathRegex = '/[a-zA-Z]+$';
             const actualPath = '/somePathThatMatchesTheRegex';
-            const route = fakeServer.get().to(pathRegex)[method]();
+
+            let route;
+            if (useNewApi) {
+                route = fakeServer.get(pathRegex)[method]();
+            } else {
+                route = fakeServer.get().to(pathRegex)[method]();
+            }
 
             const res = await fetch(`http://localhost:${port}${actualPath}`, {method: 'GET'});
 
@@ -165,7 +239,13 @@ afterEach(() => {
         test('route defined with path regex - asserting on specific path that does not match the path regex - throws', () => {
             const pathRegex = '/[0-9]+$';
             const pathThatDoesNotMatchTheRegex = '/pathThatDoesNotMatchTheRegex';
-            const route = fakeServer.get().to(pathRegex)[method]();
+
+            let route;
+            if (useNewApi) {
+                route = fakeServer.get(pathRegex)[method]();
+            } else {
+                route = fakeServer.get().to(pathRegex)[method]();
+            }
 
             expect(() => route.call.withPath(pathThatDoesNotMatchTheRegex)).toThrow();
         });
@@ -175,7 +255,13 @@ afterEach(() => {
             const actualPath = '/somePath';
             const bodyRegex = '[0-9]+$';
             const actualBody = '123';
-            const route = fakeServer.post().to(pathRegex).withBodyThatMatches(bodyRegex)[method]();
+
+            let route;
+            if (useNewApi) {
+                route = fakeServer.post(pathRegex).withBodyThatMatches(bodyRegex)[method]();
+            } else {
+                route = fakeServer.post().to(pathRegex).withBodyThatMatches(bodyRegex)[method]();
+            }
 
             const res = await fetch(`http://localhost:${port}${actualPath}`, {
                 method: 'POST',
@@ -190,49 +276,69 @@ afterEach(() => {
     });
 });
 
-describe('Route Matching - willReturn', () => {
-    test('GET route defined with default status code and called - match', async () => {
-        const path = '/somePath';
-        const route = fakeServer.get().to(path).willReturn({name: 'Morty'});
+[{useNewApi: true}, {useNewApi: false}].forEach(({useNewApi}) => {
+    describe('Route Matching - willReturn', () => {
+        test('GET route defined with default status code and called - match', async () => {
+            const path = '/somePath';
 
-        const res = await fetch(`http://localhost:${port}${path}`, {method: 'GET'});
-        const body = await res.json();
+            let route;
+            if (useNewApi) {
+                route = fakeServer.get(path).willReturn({name: 'Morty'});
+            } else {
+                route = fakeServer.get().to(path).willReturn({name: 'Morty'});
+            }
 
-        expect(body.name).toEqual('Morty');
-        expect(res.status).toEqual(200);
-        expect(fakeServer.hasMade(route.call)).toEqual(true);
-    });
+            const res = await fetch(`http://localhost:${port}${path}`, {method: 'GET'});
+            const body = await res.json();
 
-    test('GET route defined with custom status code and called - match', async () => {
-        const path = '/somePath';
-        const route = fakeServer.get().to(path).willReturn({name: 'Teapot'}, 418);
-
-        const res = await fetch(`http://localhost:${port}${path}`, {method: 'GET'});
-        const body = await res.json();
-
-        expect(body.name).toEqual('Teapot');
-        expect(res.status).toEqual(418);
-        expect(fakeServer.hasMade(route.call)).toEqual(true);
-    });
-
-    test('route defined with path and body regex - chaining assertions, specific path and body match path and body regex - assertion success', async () => {
-        const pathRegex = '/[a-zA-Z]+$';
-        const actualPath = '/somePath';
-        const bodyRegex = '[0-9]+$';
-        const actualBody = '123';
-        const requestBody = 'body as string';
-        const route = fakeServer.post().to(pathRegex).withBodyThatMatches(bodyRegex).willReturn(requestBody, 300);
-
-        const res = await fetch(`http://localhost:${port}${actualPath}`, {
-            method: 'POST',
-            headers: {'Content-Type': 'text/plain'},
-            body: actualBody,
+            expect(body.name).toEqual('Morty');
+            expect(res.status).toEqual(200);
+            expect(fakeServer.hasMade(route.call)).toEqual(true);
         });
-        const body = await res.text();
 
-        expect(res.status).toEqual(300);
-        expect(body).toEqual(requestBody);
-        expect(fakeServer.hasMade(route.call.withPath(actualPath).withBodyText(actualBody))).toEqual(true);
-        expect(fakeServer.hasMade(route.call.withBodyText(actualBody).withPath(actualPath))).toEqual(true);
+        test('GET route defined with custom status code and called - match', async () => {
+            const path = '/somePath';
+
+            let route;
+            if (useNewApi) {
+                route = fakeServer.get(path).willReturn({name: 'Teapot'}, 418);
+            } else {
+                route = fakeServer.get().to(path).willReturn({name: 'Teapot'}, 418);
+            }
+
+            const res = await fetch(`http://localhost:${port}${path}`, {method: 'GET'});
+            const body = await res.json();
+
+            expect(body.name).toEqual('Teapot');
+            expect(res.status).toEqual(418);
+            expect(fakeServer.hasMade(route.call)).toEqual(true);
+        });
+
+        test('route defined with path and body regex - chaining assertions, specific path and body match path and body regex - assertion success', async () => {
+            const pathRegex = '/[a-zA-Z]+$';
+            const actualPath = '/somePath';
+            const bodyRegex = '[0-9]+$';
+            const actualBody = '123';
+            const requestBody = 'body as string';
+            let route = fakeServer.post().to(pathRegex).withBodyThatMatches(bodyRegex).willReturn(requestBody, 300);
+
+            if (useNewApi) {
+                route = fakeServer.post(pathRegex).withBodyThatMatches(bodyRegex).willReturn(requestBody, 300);
+            } else {
+                route = fakeServer.post().to(pathRegex).withBodyThatMatches(bodyRegex).willReturn(requestBody, 300);
+            }
+
+            const res = await fetch(`http://localhost:${port}${actualPath}`, {
+                method: 'POST',
+                headers: {'Content-Type': 'text/plain'},
+                body: actualBody,
+            });
+            const body = await res.text();
+
+            expect(res.status).toEqual(300);
+            expect(body).toEqual(requestBody);
+            expect(fakeServer.hasMade(route.call.withPath(actualPath).withBodyText(actualBody))).toEqual(true);
+            expect(fakeServer.hasMade(route.call.withBodyText(actualBody).withPath(actualPath))).toEqual(true);
+        });
     });
 });

--- a/package.json
+++ b/package.json
@@ -1,45 +1,45 @@
 {
-  "name": "simple-fake-server",
-  "version": "3.2.0",
-  "description": "A small, simple http server for mocking and asserting http calls.",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "author": "soluto",
-  "license": "MIT",
-  "scripts": {
-    "precommit": "lint-staged",
-    "prepare": "npm run build",
-    "build": "rimraf dist && tsc -p tsconfig.json",
-    "test": "jest --config jest.config.json",
-    "format": "prettier --write **/*.ts **/*.tsx",
-    "prepush": "npm run test"
-  },
-  "dependencies": {
-    "deep-equal": "1.0.1",
-    "get-stream": "^5.1.0",
-    "is-subset": "0.1.1",
-    "koa": "1.5.1",
-    "koa-bodyparser": "2",
-    "koa-cors": "0.0.16",
-    "lodash": "^4.17.12",
-    "query-string": "5.0.1"
-  },
-  "devDependencies": {
-    "@types/jest": "^22.0.1",
-    "@types/node": "^9.3.0",
-    "@types/query-string": "^5.1.0",
-    "husky": "^0.14.3",
-    "into-stream": "^5.1.0",
-    "jest": "^22.1.4",
-    "lint-staged": "^6.0.1",
-    "node-fetch": "^1.7.3",
-    "prettier": "^2.0.5",
-    "rimraf": "^2.6.2",
-    "ts-jest": "^22.0.1",
-    "typescript": "^3.9.3"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Soluto/simple-fake-server"
-  }
+    "name": "simple-fake-server",
+    "version": "3.2.0",
+    "description": "A small, simple http server for mocking and asserting http calls.",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "author": "soluto",
+    "license": "MIT",
+    "scripts": {
+        "precommit": "lint-staged",
+        "prepare": "npm run build",
+        "build": "rimraf dist && tsc -p tsconfig.json",
+        "test": "jest --config jest.config.json --runInBand",
+        "format": "prettier --write **/*.ts **/*.tsx",
+        "prepush": "npm run test"
+    },
+    "dependencies": {
+        "deep-equal": "1.0.1",
+        "get-stream": "^5.1.0",
+        "is-subset": "0.1.1",
+        "koa": "1.5.1",
+        "koa-bodyparser": "2",
+        "koa-cors": "0.0.16",
+        "lodash": "^4.17.12",
+        "query-string": "5.0.1"
+    },
+    "devDependencies": {
+        "@types/jest": "^22.0.1",
+        "@types/node": "^9.3.0",
+        "@types/query-string": "^5.1.0",
+        "husky": "^0.14.3",
+        "into-stream": "^5.1.0",
+        "jest": "^22.1.4",
+        "lint-staged": "^6.0.1",
+        "node-fetch": "^1.7.3",
+        "prettier": "^2.0.5",
+        "rimraf": "^2.6.2",
+        "ts-jest": "^22.0.1",
+        "typescript": "^3.9.3"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Soluto/simple-fake-server"
+    }
 }

--- a/src/FakeHttpCalls.ts
+++ b/src/FakeHttpCalls.ts
@@ -19,7 +19,7 @@ export interface FakeRoute {
     call: RouteCallTester;
 }
 
-export interface FakeHttpMethod {
+export interface FakeHttpMethod extends With {
     to(pathRegex: string): With;
 }
 
@@ -30,30 +30,32 @@ export default class FakeHttpCalls {
         this.fakeServer = fakeServer;
     }
 
-    public post(): FakeHttpMethod {
-        return this.create('POST');
+    public post(pathRegex?: string): FakeHttpMethod {
+        return this.create('POST', pathRegex);
     }
 
     // tslint:disable-next-line:no-reserved-keywords
-    public get(): FakeHttpMethod {
-        return this.create('GET');
+    public get(pathRegex?: string): FakeHttpMethod {
+        return this.create('GET', pathRegex);
     }
 
-    public put(): FakeHttpMethod {
-        return this.create('PUT');
+    public put(pathRegex?: string): FakeHttpMethod {
+        return this.create('PUT', pathRegex);
     }
 
-    public patch(): FakeHttpMethod {
-        return this.create('PATCH');
+    public patch(pathRegex?: string): FakeHttpMethod {
+        return this.create('PATCH', pathRegex);
     }
 
     // tslint:disable-next-line:no-reserved-keywords
-    public delete(): FakeHttpMethod {
-        return this.create('DELETE');
+    public delete(pathRegex?: string): FakeHttpMethod {
+        return this.create('DELETE', pathRegex);
     }
 
     private will(method: string, pathRegex: string, bodyRestriction: BodyRestriction, queryParamsObject?: {}): Will {
-        const fakeRoute: FakeRoute = {call: new RouteCallTester(method, pathRegex, bodyRestriction, queryParamsObject)};
+        const fakeRoute: FakeRoute = {
+            call: new RouteCallTester(method, pathRegex, bodyRestriction, queryParamsObject),
+        };
 
         return {
             willReturn: (
@@ -110,15 +112,20 @@ export default class FakeHttpCalls {
         };
     }
 
-    private create(method: string): FakeHttpMethod {
+    private create(method: string, pathRegex?: string): FakeHttpMethod {
         return {
-            to: (pathRegex: string): With => ({
-                ...this.withBodyThatMatches(method, pathRegex),
-                ...this.withBodyThatContains(method, pathRegex),
-                ...this.withBody(method, pathRegex),
-                ...this.withQueryParams(method, pathRegex),
-                ...this.will(method, pathRegex, {}),
+            to: (path: string): With => ({
+                ...this.withBodyThatMatches(method, path),
+                ...this.withBodyThatContains(method, path),
+                ...this.withBody(method, path),
+                ...this.withQueryParams(method, path),
+                ...this.will(method, path, {}),
             }),
+            ...this.withBodyThatMatches(method, pathRegex || ''),
+            ...this.withBodyThatContains(method, pathRegex || ''),
+            ...this.withBody(method, pathRegex || ''),
+            ...this.withQueryParams(method, pathRegex || ''),
+            ...this.will(method, pathRegex || '', {}),
         };
     }
 }

--- a/src/FakeServer.ts
+++ b/src/FakeServer.ts
@@ -27,7 +27,7 @@ export type MockedCall = {
 };
 
 export default class FakeServer {
-    public http: FakeHttpCalls;
+    private http: FakeHttpCalls;
     private callHistory: CallHistory;
     private mockedCalls: MockedCall[];
     private port: number;
@@ -46,6 +46,26 @@ export default class FakeServer {
         this.tls = tls;
         this.http = new FakeHttpCalls(this);
         this.logger = logger;
+    }
+
+    public get() {
+        return this.http.get();
+    }
+
+    public post() {
+        return this.http.post();
+    }
+
+    public put() {
+        return this.http.put();
+    }
+
+    public delete() {
+        return this.http.delete();
+    }
+
+    public patch() {
+        return this.http.patch();
     }
 
     public start() {

--- a/src/FakeServer.ts
+++ b/src/FakeServer.ts
@@ -48,24 +48,24 @@ export default class FakeServer {
         this.logger = logger;
     }
 
-    public get() {
-        return this.http.get();
+    public get(pathRegex?: string) {
+        return this.http.get(pathRegex);
     }
 
-    public post() {
-        return this.http.post();
+    public post(pathRegex?: string) {
+        return this.http.post(pathRegex);
     }
 
-    public put() {
-        return this.http.put();
+    public put(pathRegex?: string) {
+        return this.http.put(pathRegex);
     }
 
-    public delete() {
-        return this.http.delete();
+    public delete(pathRegex?: string) {
+        return this.http.delete(pathRegex);
     }
 
-    public patch() {
-        return this.http.patch();
+    public patch(pathRegex?: string) {
+        return this.http.patch(pathRegex);
     }
 
     public start() {

--- a/src/FakeServer.ts
+++ b/src/FakeServer.ts
@@ -27,7 +27,7 @@ export type MockedCall = {
 };
 
 export default class FakeServer {
-    private http: FakeHttpCalls;
+    public http: FakeHttpCalls;
     private callHistory: CallHistory;
     private mockedCalls: MockedCall[];
     private port: number;


### PR DESCRIPTION
* Allow setting routes directly on the FakeServer (e.g FakeServer.get(...)) object instead of having to call FakeServer.http.get(...)
* Allow passing the path regex directly to the get/post/put/patch/delete functions instead of having to call to(...) 