### PR TITLE
add didReceive and callsReceived functions to FakeServer to replace hasMade and callsMade in the future

### DIFF
--- a/__tests__/body-restrictions-on-assertion-tests.ts
+++ b/__tests__/body-restrictions-on-assertion-tests.ts
@@ -35,7 +35,7 @@ afterEach(() => {
                 body: actualBody,
             });
 
-            expect(fakeServer.hasMade(route.call.withBodyText(testString))).toEqual(true);
+            expect(fakeServer.didReceive(route.call.withBodyText(testString))).toEqual(true);
         });
 
         test('regex restriction, assert on a specific string that matches the regex, request body does not equal test string (but matches regex) - assertion success', async () => {
@@ -54,7 +54,7 @@ afterEach(() => {
                 body: actualBody,
             });
 
-            expect(fakeServer.hasMade(route.call.withBodyText(testString))).toEqual(false);
+            expect(fakeServer.didReceive(route.call.withBodyText(testString))).toEqual(false);
         });
 
         test('regex restriction, assert on a specific string that does not match the regex - exception', () => {
@@ -110,7 +110,7 @@ afterEach(() => {
                 body: JSON.stringify(actualBody),
             });
 
-            expect(fakeServer.hasMade(route.call.withSpecificBody(testBody))).toEqual(true);
+            expect(fakeServer.didReceive(route.call.withSpecificBody(testBody))).toEqual(true);
         });
 
         test('partial object restriction, assert on a specific object that matches the partial object, request body does not equal test object (but matches partial object) - assertion fails', async () => {
@@ -130,7 +130,7 @@ afterEach(() => {
                 body: JSON.stringify(actualBody),
             });
 
-            expect(fakeServer.hasMade(route.call.withSpecificBody(testBody))).toEqual(false);
+            expect(fakeServer.didReceive(route.call.withSpecificBody(testBody))).toEqual(false);
         });
 
         test('partial object restriction, assert on a specific object that does not match the partial object - exception', () => {
@@ -212,7 +212,7 @@ afterEach(() => {
                 body: JSON.stringify(actualBody),
             });
 
-            expect(fakeServer.hasMade(route.call.withBodyText(testString))).toEqual(true);
+            expect(fakeServer.didReceive(route.call.withBodyText(testString))).toEqual(true);
         });
 
         test('no body restriction, assert on a specific string, no application/json header, request body equals test string - assertion success', async () => {
@@ -233,7 +233,7 @@ afterEach(() => {
                 body: actualBody,
             });
 
-            expect(fakeServer.hasMade(route.call.withBodyText(testString))).toEqual(true);
+            expect(fakeServer.didReceive(route.call.withBodyText(testString))).toEqual(true);
         });
 
         test('no body restriction, assert on a specific object, application/json header request body equals test object - assertion success', async () => {
@@ -253,7 +253,7 @@ afterEach(() => {
                 body: JSON.stringify(actualBody),
             });
 
-            expect(fakeServer.hasMade(route.call.withSpecificBody(testBody))).toEqual(true);
+            expect(fakeServer.didReceive(route.call.withSpecificBody(testBody))).toEqual(true);
         });
 
         test('no body restriction, assert on a specific object, no application/json header, request body equals test object - assertion fails', async () => {
@@ -273,7 +273,7 @@ afterEach(() => {
                 body: JSON.stringify(actualBody),
             });
 
-            expect(fakeServer.hasMade(route.call.withSpecificBody(testBody))).toEqual(false);
+            expect(fakeServer.didReceive(route.call.withSpecificBody(testBody))).toEqual(false);
         });
     });
 });

--- a/__tests__/body-restrictions-on-route-definition-tests.ts
+++ b/__tests__/body-restrictions-on-route-definition-tests.ts
@@ -41,7 +41,7 @@ afterEach(() => {
             });
 
             expect(res.status).toEqual(defaultStatus);
-            expect(fakeServer.hasMade(route.call)).toEqual(true);
+            expect(fakeServer.didReceive(route.call)).toEqual(true);
 
             const callsMade = fakeServer.callsMade(route.call);
             expect(callsMade[0].path).toEqual(path);
@@ -65,7 +65,7 @@ afterEach(() => {
             });
 
             expect(res.status).toEqual(defaultStatus);
-            expect(fakeServer.hasMade(route.call)).toEqual(true);
+            expect(fakeServer.didReceive(route.call)).toEqual(true);
         });
 
         test('route defined with regex body restriction, request body does not match regex - no match', async () => {
@@ -85,7 +85,7 @@ afterEach(() => {
             });
 
             expect(res.status).toEqual(400);
-            expect(fakeServer.hasMade(route.call)).toEqual(false);
+            expect(fakeServer.didReceive(route.call)).toEqual(false);
         });
 
         test('route defined with regex body restriction, request has "application/json", request body does not match regex - no match', async () => {
@@ -105,7 +105,7 @@ afterEach(() => {
             });
 
             expect(res.status).toEqual(400);
-            expect(fakeServer.hasMade(route.call)).toEqual(false);
+            expect(fakeServer.didReceive(route.call)).toEqual(false);
         });
 
         // route defined with partial object body restriction
@@ -128,7 +128,7 @@ afterEach(() => {
             });
 
             expect(res.status).toEqual(defaultStatus);
-            expect(fakeServer.hasMade(route.call)).toEqual(true);
+            expect(fakeServer.didReceive(route.call)).toEqual(true);
         });
 
         test('partial object restriction, request has "application/json", request body is equal to the body route object but with different property order - match', async () => {
@@ -149,7 +149,7 @@ afterEach(() => {
             });
 
             expect(res.status).toEqual(defaultStatus);
-            expect(fakeServer.hasMade(route.call)).toEqual(true);
+            expect(fakeServer.didReceive(route.call)).toEqual(true);
         });
 
         test('partial object restriction, request has "application/json", request body is a superset of the body route object - match', async () => {
@@ -170,7 +170,7 @@ afterEach(() => {
             });
 
             expect(res.status).toEqual(defaultStatus);
-            expect(fakeServer.hasMade(route.call)).toEqual(true);
+            expect(fakeServer.didReceive(route.call)).toEqual(true);
         });
 
         test('partial object restriction, request has "application/json", request body is not a superset of the body route object - no match', async () => {
@@ -191,7 +191,7 @@ afterEach(() => {
             });
 
             expect(res.status).toEqual(400);
-            expect(fakeServer.hasMade(route.call)).toEqual(false);
+            expect(fakeServer.didReceive(route.call)).toEqual(false);
         });
 
         test('partial object restriction, request has "application/json", request body is not a superset of the body route object (missing property) - no match', async () => {
@@ -211,7 +211,7 @@ afterEach(() => {
             });
 
             expect(res.status).toEqual(400);
-            expect(fakeServer.hasMade(route.call)).toEqual(false);
+            expect(fakeServer.didReceive(route.call)).toEqual(false);
         });
 
         test('partial object restriction, request has "application/json", request body is not a superset of the body route object (different value) - no match', async () => {
@@ -232,7 +232,7 @@ afterEach(() => {
             });
 
             expect(res.status).toEqual(400);
-            expect(fakeServer.hasMade(route.call)).toEqual(false);
+            expect(fakeServer.didReceive(route.call)).toEqual(false);
         });
 
         test('partial object restriction, request has "application/json", request body cannot be parsed to an object - no match', async () => {
@@ -252,7 +252,7 @@ afterEach(() => {
             });
 
             expect(res.status).toEqual(400);
-            expect(fakeServer.hasMade(route.call)).toEqual(false);
+            expect(fakeServer.didReceive(route.call)).toEqual(false);
         });
 
         test('partial object restriction, request does not have "application/json" - no match', async () => {
@@ -272,7 +272,7 @@ afterEach(() => {
             });
 
             expect(res.status).toEqual(400);
-            expect(fakeServer.hasMade(route.call)).toEqual(false);
+            expect(fakeServer.didReceive(route.call)).toEqual(false);
         });
 
         // route defined with object body restriction
@@ -295,7 +295,7 @@ afterEach(() => {
             });
 
             expect(res.status).toEqual(defaultStatus);
-            expect(fakeServer.hasMade(route.call)).toEqual(true);
+            expect(fakeServer.didReceive(route.call)).toEqual(true);
         });
 
         test('object restriction, request has "application/json", request body is equal to the body route object but with different property order - match', async () => {
@@ -315,7 +315,7 @@ afterEach(() => {
             });
 
             expect(res.status).toEqual(defaultStatus);
-            expect(fakeServer.hasMade(route.call)).toEqual(true);
+            expect(fakeServer.didReceive(route.call)).toEqual(true);
         });
 
         test('object restriction, request has "application/json", request body is a superset of the body route object - no match', async () => {
@@ -335,7 +335,7 @@ afterEach(() => {
             });
 
             expect(res.status).toEqual(400);
-            expect(fakeServer.hasMade(route.call)).toEqual(false);
+            expect(fakeServer.didReceive(route.call)).toEqual(false);
         });
 
         test('object restriction, request has "application/json", request body is a subset of the body route object - no match', async () => {
@@ -355,7 +355,7 @@ afterEach(() => {
             });
 
             expect(res.status).toEqual(400);
-            expect(fakeServer.hasMade(route.call)).toEqual(false);
+            expect(fakeServer.didReceive(route.call)).toEqual(false);
         });
 
         test('object restriction, request has "application/json", request body is different than the body route object - no match', async () => {
@@ -375,7 +375,7 @@ afterEach(() => {
             });
 
             expect(res.status).toEqual(400);
-            expect(fakeServer.hasMade(route.call)).toEqual(false);
+            expect(fakeServer.didReceive(route.call)).toEqual(false);
         });
 
         test('object restriction, request has "application/json", request body cannot be parsed to an object - no match', async () => {
@@ -395,7 +395,7 @@ afterEach(() => {
             });
 
             expect(res.status).toEqual(400);
-            expect(fakeServer.hasMade(route.call)).toEqual(false);
+            expect(fakeServer.didReceive(route.call)).toEqual(false);
         });
 
         test('object restriction, request does not have "application/json" - no match', async () => {
@@ -415,7 +415,7 @@ afterEach(() => {
             });
 
             expect(res.status).toEqual(400);
-            expect(fakeServer.hasMade(route.call)).toEqual(false);
+            expect(fakeServer.didReceive(route.call)).toEqual(false);
         });
 
         // route defined with no body restriction
@@ -431,7 +431,7 @@ afterEach(() => {
             const res = await fetch(`http://localhost:${port}${path}`, {method: 'POST'});
 
             expect(res.status).toEqual(defaultStatus);
-            expect(fakeServer.hasMade(route.call)).toEqual(true);
+            expect(fakeServer.didReceive(route.call)).toEqual(true);
         });
 
         test('no body restriction, request has "application/json", request body empty - match', async () => {
@@ -448,7 +448,7 @@ afterEach(() => {
             });
 
             expect(res.status).toEqual(defaultStatus);
-            expect(fakeServer.hasMade(route.call)).toEqual(true);
+            expect(fakeServer.didReceive(route.call)).toEqual(true);
         });
 
         test('no body restriction, request body not empty - match', async () => {
@@ -466,7 +466,7 @@ afterEach(() => {
             });
 
             expect(res.status).toEqual(defaultStatus);
-            expect(fakeServer.hasMade(route.call)).toEqual(true);
+            expect(fakeServer.didReceive(route.call)).toEqual(true);
         });
 
         test('no body restriction, request has "application/json", request body not empty - match', async () => {
@@ -484,7 +484,7 @@ afterEach(() => {
             });
 
             expect(res.status).toEqual(defaultStatus);
-            expect(fakeServer.hasMade(route.call)).toEqual(true);
+            expect(fakeServer.didReceive(route.call)).toEqual(true);
         });
 
         test('defining 2 routes with the same path with restrictions, make a call that matches only one - success + match', async () => {
@@ -505,8 +505,8 @@ afterEach(() => {
             });
 
             expect(res.status).toEqual(defaultStatus);
-            expect(fakeServer.hasMade(route1.call)).toEqual(false);
-            expect(fakeServer.hasMade(route2.call)).toEqual(true);
+            expect(fakeServer.didReceive(route1.call)).toEqual(false);
+            expect(fakeServer.didReceive(route2.call)).toEqual(true);
         });
     });
 });

--- a/__tests__/body-restrictions-on-route-definition-tests.ts
+++ b/__tests__/body-restrictions-on-route-definition-tests.ts
@@ -43,9 +43,9 @@ afterEach(() => {
             expect(res.status).toEqual(defaultStatus);
             expect(fakeServer.didReceive(route.call)).toEqual(true);
 
-            const callsMade = fakeServer.callsMade(route.call);
-            expect(callsMade[0].path).toEqual(path);
-            expect(callsMade[0].body).toEqual(actualBody);
+            const callsReceived = fakeServer.callsReceived(route.call);
+            expect(callsReceived[0].path).toEqual(path);
+            expect(callsReceived[0].body).toEqual(actualBody);
         });
 
         test('regex restriction, request has "application/json", request body matches regex - match', async () => {

--- a/__tests__/mocking-response-elements.ts
+++ b/__tests__/mocking-response-elements.ts
@@ -33,7 +33,7 @@ afterEach(() => {
             expect(body.name).toEqual('Cloud');
             expect(res.status).toEqual(200);
             expect(res.headers.get('imontop')).toEqual('Of The World');
-            expect(fakeServer.hasMade(route.call)).toEqual(true);
+            expect(fakeServer.didReceive(route.call)).toEqual(true);
         });
 
         test('GET route defined with response as stream', async () => {
@@ -51,7 +51,7 @@ afterEach(() => {
             const res = await fetch(`http://localhost:${port}${path}`, {method: 'GET'});
             expect(res.headers.get('content-type')).toEqual('application/octet-stream');
             expect(res.status).toEqual(200);
-            expect(fakeServer.hasMade(route.call)).toEqual(true);
+            expect(fakeServer.didReceive(route.call)).toEqual(true);
             const body = await getStream(res.body);
             expect(body).toEqual(stringTobeStreamed);
         });

--- a/__tests__/route-matching-general-tests.ts
+++ b/__tests__/route-matching-general-tests.ts
@@ -48,7 +48,7 @@ afterEach(() => {
             const res = await fetch(`http://localhost:${port}${path}`, {method: 'GET'});
 
             expect(res.status).toEqual(defaultStatus);
-            expect(fakeServer.hasMade(route.call)).toEqual(true);
+            expect(fakeServer.didReceive(route.call)).toEqual(true);
         });
 
         test('GET route with query params - match', async () => {
@@ -67,7 +67,7 @@ afterEach(() => {
             const res = await fetch(`http://localhost:${port}${path}${queryParams}`, {method: 'GET'});
 
             expect(res.status).toEqual(defaultStatus);
-            expect(fakeServer.hasMade(route.call)).toEqual(true);
+            expect(fakeServer.didReceive(route.call)).toEqual(true);
         });
 
         test('GET route with extra query params - no match', async () => {
@@ -85,7 +85,7 @@ afterEach(() => {
             const res = await fetch(`http://localhost:${port}${path}${queryParams}`, {method: 'GET'});
 
             expect(res.status).toEqual(400);
-            expect(fakeServer.hasMade(route.call)).toEqual(false);
+            expect(fakeServer.didReceive(route.call)).toEqual(false);
         });
 
         test('GET route with wrong query params - no match', async () => {
@@ -103,7 +103,7 @@ afterEach(() => {
             const res = await fetch(`http://localhost:${port}${path}${wrongQueryParams}`, {method: 'GET'});
 
             expect(res.status).toEqual(400);
-            expect(fakeServer.hasMade(route.call)).toEqual(false);
+            expect(fakeServer.didReceive(route.call)).toEqual(false);
         });
 
         test('GET route with partial query params - no match', async () => {
@@ -121,7 +121,7 @@ afterEach(() => {
             const res = await fetch(`http://localhost:${port}${path}${wrongQueryParams}`, {method: 'GET'});
 
             expect(res.status).toEqual(400);
-            expect(fakeServer.hasMade(route.call)).toEqual(false);
+            expect(fakeServer.didReceive(route.call)).toEqual(false);
         });
 
         test('GET route with no query params and with query restrictions - no match', async () => {
@@ -137,7 +137,7 @@ afterEach(() => {
             const res = await fetch(`http://localhost:${port}${path}`, {method: 'GET'});
 
             expect(res.status).toEqual(400);
-            expect(fakeServer.hasMade(route.call)).toEqual(false);
+            expect(fakeServer.didReceive(route.call)).toEqual(false);
         });
 
         test('GET route with query paraysm without specifying query restrictions -  match', async () => {
@@ -155,7 +155,7 @@ afterEach(() => {
             const res = await fetch(`http://localhost:${port}${path}${queryParams}`, {method: 'GET'});
 
             expect(res.status).toEqual(defaultStatus);
-            expect(fakeServer.hasMade(route.call)).toEqual(true);
+            expect(fakeServer.didReceive(route.call)).toEqual(true);
         });
 
         test('DELETE route defined and called - match', async () => {
@@ -171,7 +171,7 @@ afterEach(() => {
             const res = await fetch(`http://localhost:${port}${path}`, {method: 'DELETE'});
 
             expect(res.status).toEqual(defaultStatus);
-            expect(fakeServer.hasMade(route.call)).toEqual(true);
+            expect(fakeServer.didReceive(route.call)).toEqual(true);
         });
 
         test('PUT route defined and called - match', async () => {
@@ -187,7 +187,7 @@ afterEach(() => {
             const res = await fetch(`http://localhost:${port}${path}`, {method: 'PUT'});
 
             expect(res.status).toEqual(defaultStatus);
-            expect(fakeServer.hasMade(route.call)).toEqual(true);
+            expect(fakeServer.didReceive(route.call)).toEqual(true);
         });
 
         test('PATCH route defined and called - match', async () => {
@@ -203,7 +203,7 @@ afterEach(() => {
             const res = await fetch(`http://localhost:${port}${path}`, {method: 'PATCH'});
 
             expect(res.status).toEqual(defaultStatus);
-            expect(fakeServer.hasMade(route.call)).toEqual(true);
+            expect(fakeServer.didReceive(route.call)).toEqual(true);
         });
 
         test('route defined and not called - no match', () => {
@@ -216,7 +216,7 @@ afterEach(() => {
                 route = fakeServer.get().to(path)[method]();
             }
 
-            expect(fakeServer.hasMade(route.call)).toEqual(false);
+            expect(fakeServer.didReceive(route.call)).toEqual(false);
         });
 
         test('route defined with path regex - asserting on specific path that matches the regex - assertion success', async () => {
@@ -233,7 +233,7 @@ afterEach(() => {
             const res = await fetch(`http://localhost:${port}${actualPath}`, {method: 'GET'});
 
             expect(res.status).toEqual(defaultStatus);
-            expect(fakeServer.hasMade(route.call.withPath(actualPath))).toEqual(true);
+            expect(fakeServer.didReceive(route.call.withPath(actualPath))).toEqual(true);
         });
 
         test('route defined with path regex - asserting on specific path that does not match the path regex - throws', () => {
@@ -270,8 +270,8 @@ afterEach(() => {
             });
 
             expect(res.status).toEqual(defaultStatus);
-            expect(fakeServer.hasMade(route.call.withPath(actualPath).withBodyText(actualBody))).toEqual(true);
-            expect(fakeServer.hasMade(route.call.withBodyText(actualBody).withPath(actualPath))).toEqual(true);
+            expect(fakeServer.didReceive(route.call.withPath(actualPath).withBodyText(actualBody))).toEqual(true);
+            expect(fakeServer.didReceive(route.call.withBodyText(actualBody).withPath(actualPath))).toEqual(true);
         });
     });
 });
@@ -293,7 +293,7 @@ afterEach(() => {
 
             expect(body.name).toEqual('Morty');
             expect(res.status).toEqual(200);
-            expect(fakeServer.hasMade(route.call)).toEqual(true);
+            expect(fakeServer.didReceive(route.call)).toEqual(true);
         });
 
         test('GET route defined with custom status code and called - match', async () => {
@@ -311,7 +311,7 @@ afterEach(() => {
 
             expect(body.name).toEqual('Teapot');
             expect(res.status).toEqual(418);
-            expect(fakeServer.hasMade(route.call)).toEqual(true);
+            expect(fakeServer.didReceive(route.call)).toEqual(true);
         });
 
         test('route defined with path and body regex - chaining assertions, specific path and body match path and body regex - assertion success', async () => {
@@ -337,8 +337,8 @@ afterEach(() => {
 
             expect(res.status).toEqual(300);
             expect(body).toEqual(requestBody);
-            expect(fakeServer.hasMade(route.call.withPath(actualPath).withBodyText(actualBody))).toEqual(true);
-            expect(fakeServer.hasMade(route.call.withBodyText(actualBody).withPath(actualPath))).toEqual(true);
+            expect(fakeServer.didReceive(route.call.withPath(actualPath).withBodyText(actualBody))).toEqual(true);
+            expect(fakeServer.didReceive(route.call.withBodyText(actualBody).withPath(actualPath))).toEqual(true);
         });
     });
 });

--- a/__tests__/route-matching-general-tests.ts
+++ b/__tests__/route-matching-general-tests.ts
@@ -20,7 +20,7 @@ afterEach(() => {
     {method: 'willFail', defaultStatus: 500, useNewApi: true},
 ].forEach(({method, defaultStatus, useNewApi}) => {
     describe(`Route Matching - ${method}`, () => {
-        test('GET route defined, one call matches and two dont, callsMade returns only the matching call', async () => {
+        test('GET route defined, one call matches and two dont, callsReceived returns only the matching call', async () => {
             const path = '/somePath';
             let route;
             if (useNewApi) {
@@ -33,7 +33,7 @@ afterEach(() => {
             await fetch(`http://localhost:${port}${path}`, {method: 'PUT'});
             await fetch(`http://localhost:${port}${path}`, {method: 'POST'});
 
-            expect(fakeServer.callsMade(route.call).length).toEqual(1);
+            expect(fakeServer.callsReceived(route.call).length).toEqual(1);
         });
 
         test('GET route defined and called - match', async () => {

--- a/readme.md
+++ b/readme.md
@@ -141,12 +141,12 @@ await fetch('/your/api', {method: 'GET'});
 console.log(fakeServer.didReceive(route.call)); // true
 ```
 
--   **`callsMade(routeCallTester: RouteCallTester)`**  
-    Returns an array of all calls made that match the provided route.  
+-   **`callsReceived(routeCallTester: RouteCallTester)`**  
+    Returns an array of all calls received that match the provided route.  
     Each entry of the array is an object containing `method`, `path`, `headers` and `body`.
 
 -   **`clearCallHistory()`**  
-    Self explanatory. After calling clearCallHistory didReceive will always return false and callsMade will always return an empty array until the next call is made.
+    Self explanatory. After calling clearCallHistory didReceive will always return false and callsReceived will always return an empty array until the next call is made.
 
 ### Assertion Constrains
 

--- a/readme.md
+++ b/readme.md
@@ -1,28 +1,31 @@
 # simple-fake-server
-A small, simple http server for mocking and asserting http calls.  
-This server was developed mainly to isolate the client side code during automation and integration tests.  
 
-+ [Installation](#installation)
-+ [Usage Example](#usage-example)
-+ [Defining Fake Routes](#defining-routes)
-    + [Supported HTTP Methods](#supported-http-methods)
-    + [Response](#response)
-    + [Route Restrictions](#route-restrictions)
-+ [Assertions](#assertions)
-    + [Assertion Methods](#assertion-methods)
-    + [Assertion Constrains](#assertion-constrains)
-+ [More Usage Examples](#more-usage-examples)
+A small, simple http server for mocking and asserting http calls.  
+This server was developed mainly to isolate the client side code during automation and integration tests.
+
+-   [Installation](#installation)
+-   [Usage Example](#usage-example)
+-   [Defining Fake Routes](#defining-routes)
+    -   [Supported HTTP Methods](#supported-http-methods)
+    -   [Response](#response)
+    -   [Route Restrictions](#route-restrictions)
+-   [Assertions](#assertions)
+    -   [Assertion Methods](#assertion-methods)
+    -   [Assertion Constrains](#assertion-constrains)
+-   [More Usage Examples](#more-usage-examples)
 
 ## Installation
+
 `npm install simple-fake-server --save-dev`
 
 ## Usage Example
+
 ```js
 import { FakeServer } from 'simple-fake-server');
 
 describe('Test Example', () => {
     let fakeServer;
-    
+
     before(() => {
         fakeServer = new FakeServer(1234);
         fakeServer.start(); //The FakeServer now listens on http://localhost:1234
@@ -36,7 +39,7 @@ describe('Test Example', () => {
 
         expect(response.status).toEqual(200);
         expect(body.message).toEqual("hello world");
-        expect(fakeServer.hasMade(route.call)).toEqual(true);
+        expect(fakeServer.didReceive(route.call)).toEqual(true);
     });
 
     after(() => {
@@ -46,69 +49,71 @@ describe('Test Example', () => {
 ```
 
 ## Running inside a docker container
+
 see [simple-fake-server-server](http-host/README.md)
 
 ## Defining Routes
 
 ```js
 const route = fakeServer.http
-    .get()  // Http Method (mandatory). See Supported HTTP Methods section.
+    .get() // Http Method (mandatory). See Supported HTTP Methods section.
     .to(pathRegex) // Route Path (mandatory). May be regex
     .withBody(object) // Route Restriction (optional). See Route Restrictions section.
-    .willSucceed() // Route Response (mandatory). See Response Section
+    .willSucceed(); // Route Response (mandatory). See Response Section
 ```
 
 ### Supported HTTP Methods
 
-The following http methods are available under `fakeServer.http`:  
-* get()
-* post()
-* put()
-* delete()
-* patch()
+The following http methods are available under `fakeServer.http`:
+
+-   get()
+-   post()
+-   put()
+-   delete()
+-   patch()
 
 ### Response
 
 Response is mandatory and need to be set on any defined route.
 
-* **`willSucceed()`** - a request to route that was defined with willSucceed will return status code 200 and `{}` body.
+-   **`willSucceed()`** - a request to route that was defined with willSucceed will return status code 200 and `{}` body.
 
-* **`willFail(errorStatusCode?: number)`** - a request to route that was defined with willFail will return status code `errorStatusCode` (default is 500 if none provided) and `{}` body.
+-   **`willFail(errorStatusCode?: number)`** - a request to route that was defined with willFail will return status code `errorStatusCode` (default is 500 if none provided) and `{}` body.
 
-* **`willReturn(response: any, statusCode?: number)`** - a request to route that was defined with willReturn will return status code `statusCode` (default is 200 if none provided) and `response` body.
+-   **`willReturn(response: any, statusCode?: number)`** - a request to route that was defined with willReturn will return status code `statusCode` (default is 200 if none provided) and `response` body.
 
 ### Route Restrictions
 
 Restrictions are optional and can be defined after `to(path)`. Only **one** restriction can be set per route definition.  
 Chaining more than one restriction will result in an error.
 
-
-* **`withBody(body: object)`**  
-Will match only requests with content-type header set to 'application/json' and bodies that are objects that **deeply equal** the given body:
+-   **`withBody(body: object)`**  
+    Will match only requests with content-type header set to 'application/json' and bodies that are objects that **deeply equal** the given body:
 
 ```js
-const withBodyRoute = fakeServer.http.post().to('/some/path').withBody({ a: 1, b: 2 }).willSucceed();
+const withBodyRoute = fakeServer.http.post().to('/some/path').withBody({a: 1, b: 2}).willSucceed();
 
 // Request to /some/path with body { a: 1, b: 2 } => Success, 200 status code.
 // Request to /some/path with body { a: 1, b: 2, c: 3 } => Fail, 400 status code.
 ```
 
-* **`withBodyThatMatches(regex: string)`**   
-Will match only requests with body that match the given **regex**.  
-i.e. route defined with `withBodyThatMatches('[a-zA-Z]+$')` will accept request body `abc` but will reject `123`.
+-   **`withBodyThatMatches(regex: string)`**  
+    Will match only requests with body that match the given **regex**.  
+    i.e. route defined with `withBodyThatMatches('[a-zA-Z]+$')` will accept request body `abc` but will reject `123`.
 
-* **`withBodyThatContains(partialObject: object)`**   
-Will match only requests with content-type header set to 'application/json' and bodies that are *supersets* of the given body.
-i.e. route defined with `withBodyThatContains({ a: 1, b: 2 })` will accept request body `{ a: 1, b: 2, c: 3}`.
+-   **`withBodyThatContains(partialObject: object)`**  
+    Will match only requests with content-type header set to 'application/json' and bodies that are _supersets_ of the given body.
+    i.e. route defined with `withBodyThatContains({ a: 1, b: 2 })` will accept request body `{ a: 1, b: 2, c: 3}`.
 
-* **`withQueryParams(queryParams: object)`**   
-Will only match requests that match exactly the query params set on `queryParams`.  
-i.e. route defined with `withQueryParams({ someQuery: true })` will match requests to `some/path?someQuery=true` but will reject `some/path?someQuery=false` or `some/path?someQuery=true&other=something`.
+-   **`withQueryParams(queryParams: object)`**  
+    Will only match requests that match exactly the query params set on `queryParams`.  
+    i.e. route defined with `withQueryParams({ someQuery: true })` will match requests to `some/path?someQuery=true` but will reject `some/path?someQuery=false` or `some/path?someQuery=true&other=something`.
 
 <br/><br/>
-NOTES: 
-* A request that failed to fulfill a restriction will return 400 and will result in false when asserting with `hasMade` (more on this on the next section).
-* When setting 2 or more routes with the same path, but with different body restrictions, it's enough to fulfill just 1 of the restrictions to get a match.
+NOTES:
+
+-   A request that failed to fulfill a restriction will return 400 and will result in false when asserting with `didReceive` (more on this on the next section).
+-   When setting 2 or more routes with the same path, but with different body restrictions, it's enough to fulfill just 1 of the restrictions to get a match.
 
 ## Assertions
 
@@ -124,51 +129,52 @@ const routeCallTester = route.call;
 
 fakeServer instance exposes 3 methods that can be helpful for your tests assertions.
 
-* **`hasMade(routeCallTester: RouteCallTester)`**   
-Returns true/false, based on whether this route was called since the server was started.  
-Usage example:
+-   **`didReceive(routeCallTester: RouteCallTester)`**  
+    Returns true/false, based on whether this route was called since the server was started.  
+    Usage example:
+
 ```js
 const route = fakeServer.http.get().to('/your/api').willSucceed();
 
-console.log(fakeServer.hasMade(route.call)); // false
-await fetch('/your/api', { method: 'GET' });
-console.log(fakeServer.hasMade(route.call)); // true
+console.log(fakeServer.didReceive(route.call)); // false
+await fetch('/your/api', {method: 'GET'});
+console.log(fakeServer.didReceive(route.call)); // true
 ```
 
-* **`callsMade(routeCallTester: RouteCallTester)`**  
-Returns an array of all calls made that match the provided route.   
-Each entry of the array is an object containing `method`, `path`, `headers` and `body`.
+-   **`callsMade(routeCallTester: RouteCallTester)`**  
+    Returns an array of all calls made that match the provided route.  
+    Each entry of the array is an object containing `method`, `path`, `headers` and `body`.
 
-* **`clearCallHistory()`**  
-Self explanatory. After calling clearCallHistory hasMade will always return false and callsMade will always return an empty array until the next call is made.
+-   **`clearCallHistory()`**  
+    Self explanatory. After calling clearCallHistory didReceive will always return false and callsMade will always return an empty array until the next call is made.
 
 ### Assertion Constrains
 
-It's possible to add a constrain to the routeCallTester. It's useful when the route was defined with a regex or a body restriction and you want to make sure *exactly* what was the route called with.
+It's possible to add a constrain to the routeCallTester. It's useful when the route was defined with a regex or a body restriction and you want to make sure _exactly_ what was the route called with.
 
-* **`withPath(specificPath: string)`**  
-Comes useful when defining a route with regex and you'd like to assert a specific path was called.  
-Usage example:
+-   **`withPath(specificPath: string)`**  
+    Comes useful when defining a route with regex and you'd like to assert a specific path was called.  
+    Usage example:
 
 ```js
 const route = fakeServer.http.get().to('/some/path/[a-zA-Z]+$').willSucceed();
-await fetch('/some/path/xyz', { method: 'GET' });
+await fetch('/some/path/xyz', {method: 'GET'});
 
-console.log(fakeServer.hasMade(route.call.withPath('/some/path/xyz'))); // true
-console.log(fakeServer.hasMade(route.call.withPath('/some/path/abc'))); // false
+console.log(fakeServer.didReceive(route.call.withPath('/some/path/xyz'))); // true
+console.log(fakeServer.didReceive(route.call.withPath('/some/path/abc'))); // false
 ```
 
-* **`withBodyText(text: string)`**  
-Comes useful when defining a route with `withBodyThatMatches` using regex and you'd like to assert a specific body text was called with.  
+-   **`withBodyText(text: string)`**  
+    Comes useful when defining a route with `withBodyThatMatches` using regex and you'd like to assert a specific body text was called with.
 
-* **`withSpecificBody(body: object)`**  
-Comes useful when defining a route with `withBodyThatContains` and you'd like to assert a specific body object was called with.  
+-   **`withSpecificBody(body: object)`**  
+    Comes useful when defining a route with `withBodyThatContains` and you'd like to assert a specific body object was called with.
 
 ## More Usage Examples
 
 You can check out our tests section to see a bunch of different usage examples.
 
-* [General Route Matching](./__tests__/route-matching-general-tests.ts)
-* [Body Restrictions on Route Definition](./__tests__/body-restrictions-on-route-definition-tests.ts)
-* [Assertions Constrains](./__tests__/body-restrictions-on-assertion-tests.ts)
-* [Mocking Response Elements](./__tests__/mocking-response-elements.ts)
+-   [General Route Matching](./__tests__/route-matching-general-tests.ts)
+-   [Body Restrictions on Route Definition](./__tests__/body-restrictions-on-route-definition-tests.ts)
+-   [Assertions Constrains](./__tests__/body-restrictions-on-assertion-tests.ts)
+-   [Mocking Response Elements](./__tests__/mocking-response-elements.ts)

--- a/src/FakeServer.ts
+++ b/src/FakeServer.ts
@@ -175,6 +175,10 @@ export default class FakeServer {
         return this.callHistory.get().some(this.match(call));
     }
 
+    public didReceive(call: MockedCall) {
+        return this.hasMade(call);
+    }
+
     public callsMade(call: MockedCall) {
         return this.callHistory.get().filter(this.match(call));
     }

--- a/src/FakeServer.ts
+++ b/src/FakeServer.ts
@@ -183,6 +183,10 @@ export default class FakeServer {
         return this.callHistory.get().filter(this.match(call));
     }
 
+    public callsReceived(call: MockedCall) {
+        return this.callHistory.get().filter(this.match(call));
+    }
+
     private match(mockedCall: MockedCall) {
         return (serverCall: Call) => {
             const contentTypeIsApplicationJson = serverCall.headers['content-type'] === 'application/json';


### PR DESCRIPTION
FakeServer doesn't make any calls, it only receives them, so the naming 'hasMade' for a function that checks if the server received a request doesn't make sense. The same can be said about the 'callsMade' function.

this PR adds two new functions, called 'didReceive' and 'callsReceived', which has better names and the same logic as 'hasMade' and 'callsMade' respectively.

in future versions of simple-fake-server 'hasMade' and 'callsMade' should be removed.